### PR TITLE
Dont try to build fv3net image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       image:
         default: fv3net
         type: enum
-        enum: ["prognostic_run", "post_process_run", "fv3net", "fv3fit"]
+        enum: ["prognostic_run", "post_process_run", "fv3net"]
     machine: 
       image: ubuntu-1604:202007-01
     environment:
@@ -244,7 +244,7 @@ workflows:
       - build_default:
           matrix:
             parameters:
-              image: ["prognostic_run", "fv3net", "post_process_run", "fv3fit"]
+              image: ["prognostic_run", "fv3net", "post_process_run"]
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
#1092 removed the fv3fit image, but CI is still trying to build it. This PR resolves this issue.