### PR TITLE
Fix SST setting logic

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -47,8 +47,6 @@ spec:
               minutes: 30
             fv_core_nml:
               do_sat_adj: false
-            gfs_physics_nml:
-              use_climatological_sst: false
             gfdl_cloud_microphysics_nml:
               fast_sat_adj: false
           fortran_diagnostics:

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -47,6 +47,8 @@ spec:
               minutes: 30
             fv_core_nml:
               do_sat_adj: false
+            gfs_physics_nml:
+              use_climatological_sst: false
             gfdl_cloud_microphysics_nml:
               fast_sat_adj: false
           fortran_diagnostics:

--- a/workflows/prognostic_c48_run/docs/config-usage.rst
+++ b/workflows/prognostic_c48_run/docs/config-usage.rst
@@ -63,6 +63,15 @@ Notice how these configurations correspond with
 :py:attr:`runtime.config.UserConfig.nudging`. Refer to those docs as a
 reference.
 
+In addition to the above settings, to prescribe the sea surface temperatures to
+the values in the reference restart files, the
+``gfs_physics_nml.use_climatological_sst`` namelist parameter must be set to
+``false``::
+
+    namelist:
+        gfs_physics_nml:
+            use_climatological_sst: false
+
 .. _nudge to obs:
 
 Nudge to obs

--- a/workflows/prognostic_c48_run/docs/config-usage.rst
+++ b/workflows/prognostic_c48_run/docs/config-usage.rst
@@ -63,15 +63,6 @@ Notice how these configurations correspond with
 :py:attr:`runtime.config.UserConfig.nudging`. Refer to those docs as a
 reference.
 
-In addition to the above settings, to prescribe the sea surface temperatures to
-the values in the reference restart files, the
-``gfs_physics_nml.use_climatological_sst`` namelist parameter must be set to
-``false``::
-
-    namelist:
-        gfs_physics_nml:
-            use_climatological_sst: false
-
 .. _nudge to obs:
 
 Nudge to obs

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -238,8 +238,9 @@ def get_nudging_tendency(
 
 def get_reference_surface_temperatures(state: State, reference: State) -> State:
     """
-    Set the sea surface temperature model state to values in a reference state.
-    Useful for maintaining consistency between a nudged run and reference state.
+    Set the sea surface and surface temperatures in a model state to values in
+    a reference state. Useful for maintaining consistency between a nudged run
+    and reference state.
     """
     state = {
         SST_NAME: _sst_from_reference(

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -250,11 +250,12 @@ def get_reference_surface_temperatures(state: State, reference: State) -> State:
             reference[TSFC_NAME], state[TSFC_NAME], state[MASK_NAME]
         ),
     }
+    return state
     # TODO fix this bug in a follow-up non-refactor PR
     # this logic replicates a bug in the previous nudged run
     # the SSTs were never actually applied to the fv3gfs-wrapper state
     # This bug could be scientifically significant.
-    return {}
+    # return {}
 
 
 def _sst_from_reference(

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -242,6 +242,9 @@ def get_reference_surface_temperatures(state: State, reference: State) -> State:
     Useful for maintaining consistency between a nudged run and reference state.
     """
     state = {
+        TSFC_NAME: _sst_from_reference(
+            reference[TSFC_NAME], state[TSFC_NAME], state[MASK_NAME]
+        ),
         SST_NAME: _sst_from_reference(
             reference[TSFC_NAME], state[SST_NAME], state[MASK_NAME]
         ),

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -242,11 +242,11 @@ def get_reference_surface_temperatures(state: State, reference: State) -> State:
     Useful for maintaining consistency between a nudged run and reference state.
     """
     state = {
-        TSFC_NAME: _sst_from_reference(
-            reference[TSFC_NAME], state[TSFC_NAME], state[MASK_NAME]
-        ),
         SST_NAME: _sst_from_reference(
             reference[TSFC_NAME], state[SST_NAME], state[MASK_NAME]
+        ),
+        TSFC_NAME: _sst_from_reference(
+            reference[TSFC_NAME], state[TSFC_NAME], state[MASK_NAME]
         ),
     }
     return state

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -238,24 +238,15 @@ def get_nudging_tendency(
 
 def get_reference_surface_temperatures(state: State, reference: State) -> State:
     """
-    Set the sea surface and surface temperatures in a model state to values in
-    a reference state. Useful for maintaining consistency between a nudged run
-    and reference state.
+    Set the sea surface temperature model state to values in a reference state.
+    Useful for maintaining consistency between a nudged run and reference state.
     """
     state = {
         SST_NAME: _sst_from_reference(
             reference[TSFC_NAME], state[SST_NAME], state[MASK_NAME]
         ),
-        TSFC_NAME: _sst_from_reference(
-            reference[TSFC_NAME], state[TSFC_NAME], state[MASK_NAME]
-        ),
     }
     return state
-    # TODO fix this bug in a follow-up non-refactor PR
-    # this logic replicates a bug in the previous nudged run
-    # the SSTs were never actually applied to the fv3gfs-wrapper state
-    # This bug could be scientifically significant.
-    # return {}
 
 
 def _sst_from_reference(


### PR DESCRIPTION
This PR restores the logic needed to update the sea surface temperature via the Python wrapper.

Resolves #1037

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

