### PR TITLE
Add `-m mpi4py` to runfv3 python call

### DIFF
--- a/workflows/prognostic_c48_run/runfv3
+++ b/workflows/prognostic_c48_run/runfv3
@@ -148,7 +148,7 @@ function runSegment {
     (
         cd "$rundir"
         NUM_PROC=$(yq '.namelist.fv_core_nml.layout | .[0] *.[1] * 6' "$fv3config")
-        mpirun -n "$NUM_PROC" python3 "$runfile" |& tee -a "$rundir/logs.txt"
+        mpirun -n "$NUM_PROC" python3 -m mpi4py "$runfile" |& tee -a "$rundir/logs.txt"
     )
 }
 


### PR DESCRIPTION
This change should ensure prognostic runs will properly exit if an error is raised on one rank but not on others.

see: https://mpi4py.readthedocs.io/en/stable/mpi4py.run.html