### PR TITLE
Mask pressure level values if extrapolated below surface

### DIFF
--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -328,6 +328,7 @@ for variable_set in ["dycore", "physics"]:
     @add_to_diags(variable_set)
     @diag_finalizer("zonal_mean_value")
     @transform.apply("resample_time", "3H", inner_join=True)
+    @transform.apply("mask_values_below_sfc")
     @transform.apply("daily_mean", datetime.timedelta(days=10))
     @transform.apply("subset_variables", subset_variables)
     def zonal_mean_hovmoller(prognostic, verification, grid):
@@ -337,6 +338,7 @@ for variable_set in ["dycore", "physics"]:
     @add_to_diags(variable_set)
     @diag_finalizer("zonal_mean_bias")
     @transform.apply("resample_time", "3H", inner_join=True)
+    @transform.apply("mask_values_below_sfc")
     @transform.apply("daily_mean", datetime.timedelta(days=10))
     @transform.apply("subset_variables", subset_variables)
     def zonal_mean_bias_hovmoller(prognostic, verification, grid):
@@ -356,6 +358,7 @@ for var_set in ["dycore", "physics"]:
         @diag_finalizer(f"spatial_min_{var_set}_{mask_type}")
         @transform.apply("mask_area", mask_type)
         @transform.apply("resample_time", "3H")
+        @transform.apply("mask_values_below_sfc")
         @transform.apply("daily_mean", datetime.timedelta(days=10))
         @transform.apply("subset_variables", subset_variables)
         def spatial_min(prognostic, verification, grid, mask_type=mask_type):
@@ -376,6 +379,7 @@ for var_set in ["dycore", "physics"]:
         @diag_finalizer(f"spatial_max_{var_set}_{mask_type}")
         @transform.apply("mask_area", mask_type)
         @transform.apply("resample_time", "3H")
+        @transform.apply("mask_values_below_sfc")
         @transform.apply("daily_mean", datetime.timedelta(days=10))
         @transform.apply("subset_variables", subset_variables)
         def spatial_max(prognostic, verification, grid, mask_type=mask_type):
@@ -390,6 +394,7 @@ for mask_type in ["global", "land", "sea", "tropics"]:
     @diag_finalizer(f"spatial_mean_dycore_{mask_type}")
     @transform.apply("mask_area", mask_type)
     @transform.apply("resample_time", "3H")
+    @transform.apply("mask_values_below_sfc")
     @transform.apply("daily_mean", datetime.timedelta(days=10))
     @transform.apply("subset_variables", GLOBAL_AVERAGE_DYCORE_VARS)
     def global_averages_dycore(prognostic, verification, grid, mask_type=mask_type):
@@ -439,6 +444,7 @@ for mask_type in ["global", "land", "sea", "tropics"]:
     @diag_finalizer(f"mean_bias_dycore_{mask_type}")
     @transform.apply("mask_area", mask_type)
     @transform.apply("resample_time", "3H", inner_join=True)
+    @transform.apply("mask_values_below_sfc")
     @transform.apply("daily_mean", datetime.timedelta(days=10))
     @transform.apply("subset_variables", GLOBAL_AVERAGE_DYCORE_VARS)
     def global_biases_dycore(prognostic, verification, grid, mask_type=mask_type):
@@ -469,18 +475,20 @@ def time_mean_biases_physics(prognostic, verification, grid):
 @add_to_diags("dycore")
 @diag_finalizer("time_mean_value")
 @transform.apply("resample_time", "1H", inner_join=True)
+@transform.apply("mask_values_below_sfc")
 @transform.apply("subset_variables", TIME_MEAN_VARS)
 def time_means_dycore(prognostic, verification, grid):
-    logger.info("Preparing time means for physics variables")
+    logger.info("Preparing time means for dycore variables")
     return time_mean(prognostic)
 
 
 @add_to_diags("dycore")
 @diag_finalizer("time_mean_bias")
 @transform.apply("resample_time", "1H", inner_join=True)
+@transform.apply("mask_values_below_sfc")
 @transform.apply("subset_variables", TIME_MEAN_VARS)
 def time_mean_biases_dycore(prognostic, verification, grid):
-    logger.info("Preparing time mean biases for physics variables")
+    logger.info("Preparing time mean biases for dycore variables")
     return time_mean(prognostic - verification)
 
 
@@ -521,7 +529,7 @@ def register_parser(subparsers):
         type=int,
         help="Parallelism for the computation of diagnostics. "
         "Defaults to using all available cores. Can set to a lower fixed value "
-        "if you are often running  into read errors when multiple processes "
+        "if you are often running into read errors when multiple processes "
         "access data concurrently.",
         default=-1,
     )

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -240,6 +240,7 @@ def dump_nc(ds: xr.Dataset, f):
 @add_to_diags("dycore")
 @diag_finalizer("rms_global")
 @transform.apply("resample_time", "3H", inner_join=True)
+@transform.apply("mask_values_below_sfc")
 @transform.apply("daily_mean", datetime.timedelta(days=10))
 @transform.apply("subset_variables", RMSE_VARS)
 def rms_errors(prognostic, verification_c48, grid):
@@ -252,6 +253,7 @@ def rms_errors(prognostic, verification_c48, grid):
 @add_to_diags("dycore")
 @diag_finalizer("zonal_and_time_mean")
 @transform.apply("resample_time", "1H")
+@transform.apply("mask_values_below_sfc")
 @transform.apply("subset_variables", GLOBAL_AVERAGE_DYCORE_VARS)
 def zonal_means_dycore(prognostic, verification, grid):
     logger.info("Preparing zonal+time means (dycore)")
@@ -294,6 +296,7 @@ def zonal_bias_3d(prognostic, verification, grid):
 @add_to_diags("dycore")
 @diag_finalizer("zonal_bias")
 @transform.apply("resample_time", "1H")
+@transform.apply("mask_values_below_sfc")
 @transform.apply("subset_variables", GLOBAL_AVERAGE_DYCORE_VARS)
 def zonal_and_time_mean_biases_dycore(prognostic, verification, grid):
     logger.info("Preparing zonal+time mean biases (dycore)")


### PR DESCRIPTION
The fortran diagnostics and `vcm.interpolate_to_pressure_levels` handle pressure levels below the surface differently: the fortran diags extrapolates if surface pressure is less than the variable's pressure level (i.e. TMP850 has a finite value even if surface pressure < 850 hPa) while `vcm.interpolate_to_pressure_levels` leaves the value as NaN. Since the recently added 2D dycore verification variables in `vcm.catalog["40day_c48_atmos_8xdaily_additional_vars_may2020"]` use the vcm interpolation to save TMP850, etc. but the prognostic run uses the fortran diagnostics, this means the prognostic run report will be comparing different sets of points between the verification and the prognostic run for these variables.

This PR adds a `mask_values_below_sfc` transform step, which checks whether a subset of lower atmosphere variables at pressure levels P has values in columns with Psfc < P. Only columns that have Psfc >= P are kept for computing values in the report.

