### PR TITLE
Use double precision in StandardScaler

### DIFF
--- a/external/fv3fit/fv3fit/_shared/scaler.py
+++ b/external/fv3fit/fv3fit/_shared/scaler.py
@@ -41,7 +41,7 @@ class StandardScaler(NormalizeTransform):
 
     kind: str = "standard"
 
-    def __init__(self, std_epsilon: np.float32 = 1e-12):
+    def __init__(self, std_epsilon: np.float64 = 1e-12):
         """Standard scaler normalizer: normalizes via (x-mean)/std
 
         Args:
@@ -52,11 +52,11 @@ class StandardScaler(NormalizeTransform):
         """
         self.mean = None
         self.std = None
-        self.std_epsilon: np.float32 = std_epsilon
+        self.std_epsilon: np.float64 = std_epsilon
 
     def fit(self, data: np.ndarray):
-        self.mean = data.mean(axis=0).astype(np.float32)
-        self.std = data.std(axis=0).astype(np.float32) + self.std_epsilon
+        self.mean = data.mean(axis=0).astype(np.float64)
+        self.std = data.std(axis=0).astype(np.float64) + self.std_epsilon
 
     def normalize(self, data):
         if self.mean is None or self.std is None:

--- a/external/fv3fit/tests/_regtest_outputs/test_sklearn_wrapper.test_predict_columnwise_is_deterministic.out
+++ b/external/fv3fit/tests/_regtest_outputs/test_sklearn_wrapper.test_predict_columnwise_is_deterministic.out
@@ -1,1 +1,1 @@
-2cdda8d7b55ef5a78b41596a2148f09e
+fe1edd06a4cdb3bbca2652fc980a4d65

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_machine_learning.test_ml_steppers_regression_checksum[MLStateStepper].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_machine_learning.test_ml_steppers_regression_checksum[MLStateStepper].out
@@ -2,16 +2,16 @@
   - []
 - - diagnostics
   - - - downward_longwave
-      - 8b886991eea4c48475709bca29505185
+      - 05b81bc8a3653f45e6343f54575fa1a9
     - - downward_shortwave
-      - 47735602b45938d453a31013ef9410ba
+      - 2629711def7511e9821d7607a95e1dec
     - - net_shortwave
-      - 01b249036fc7c5eec78879aa849ec524
+      - de78311f51b3a88b5fdbd1f32b2edcb5
 - - states
   - - - downward_longwave
-      - 8b886991eea4c48475709bca29505185
+      - 05b81bc8a3653f45e6343f54575fa1a9
     - - downward_shortwave
-      - 47735602b45938d453a31013ef9410ba
+      - 2629711def7511e9821d7607a95e1dec
     - - net_shortwave
-      - 01b249036fc7c5eec78879aa849ec524
+      - de78311f51b3a88b5fdbd1f32b2edcb5
 

--- a/workflows/prognostic_c48_run/tests/_regtest_outputs/test_machine_learning.test_ml_steppers_regression_checksum[PureMLStepper].out
+++ b/workflows/prognostic_c48_run/tests/_regtest_outputs/test_machine_learning.test_ml_steppers_regression_checksum[PureMLStepper].out
@@ -2,11 +2,11 @@
   - - - dQ1
       - 3d480f027a2bfdac6a6b541db6a33c11
     - - dQ2
-      - 15882fafc5c05cf2951d4087e89afa87
+      - f994e16a942082836c9af5200e6fc3e1
     - - dQu
-      - 25447ea29d508fc84c2c655e7d60a523
+      - e7266ef3458844030cd640bd5d705371
     - - dQv
-      - 25447ea29d508fc84c2c655e7d60a523
+      - e7266ef3458844030cd640bd5d705371
 - - diagnostics
   - - - column_integrated_dQ1_change_non_neg_sphum_constraint
       - fcc46bebe36ea131688f8e15700e18d4


### PR DESCRIPTION
When normalizing, precision is important, especially when the mean can be much larger than variability and we may repeatedly normalize and de-normalize values. This PR updates the StandardScaler to use double precision instead of single precision for mean and standard deviation.

Significant internal changes:
- StandardScaler now uses float64 instead of float32 for mean and standard deviation

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

