### PR TITLE
prognostic_run: Make UserConfig.scikit_learn optional, simplify init

### DIFF
--- a/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudge_to_obs_config_regression.out
+++ b/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudge_to_obs_config_regression.out
@@ -1720,11 +1720,7 @@ namelist:
 nudging: null
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 prephysics: null
-scikit_learn:
-  diagnostic_ml: false
-  input_standard_names: {}
-  model: []
-  output_standard_names: {}
+scikit_learn: null
 step_storage_variables:
 - specific_humidity
 - total_water

--- a/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudging_config_regression.out
+++ b/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudging_config_regression.out
@@ -1616,11 +1616,7 @@ nudging:
     y_wind: 12
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 prephysics: null
-scikit_learn:
-  diagnostic_ml: false
-  input_standard_names: {}
-  model: []
-  output_standard_names: {}
+scikit_learn: null
 step_storage_variables:
 - specific_humidity
 - total_water

--- a/workflows/prognostic_c48_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/prepare_config.py
@@ -4,7 +4,7 @@ import yaml
 import logging
 import sys
 from datetime import datetime, timedelta
-from typing import List, Mapping, Optional, Sequence, Union
+from typing import List, Mapping, Optional, Sequence
 
 import dacite
 
@@ -21,7 +21,6 @@ from runtime.diagnostics.fortran import file_configs_to_namelist_settings
 from runtime.steppers.nudging import NudgingConfig
 from runtime.config import UserConfig
 from runtime.steppers.machine_learning import MachineLearningConfig
-from runtime.steppers.prescriber import PrescriberConfig
 
 
 logger = logging.getLogger(__name__)

--- a/workflows/prognostic_c48_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/prepare_config.py
@@ -148,7 +148,7 @@ def _default_diagnostics(
 ) -> List[DiagnosticFileConfig]:
     diagnostic_files: List[DiagnosticFileConfig] = []
 
-    if scikit_learn:
+    if scikit_learn is not None:
         diagnostic_files.append(default_diagnostics.ml_diagnostics)
     elif nudging or nudge_to_obs:
         diagnostic_files.append(default_diagnostics.state_after_timestep)

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -43,7 +43,7 @@ class UserConfig:
         default_factory=list
     )
     prephysics: Optional[Union[PrescriberConfig, MachineLearningConfig]] = None
-    scikit_learn: MachineLearningConfig = MachineLearningConfig()
+    scikit_learn: Optional[MachineLearningConfig] = None
     nudging: Optional[NudgingConfig] = None
     step_tendency_variables: List[str] = dataclasses.field(
         default_factory=lambda: list(

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -36,8 +36,12 @@ class UserConfig:
             diagnostics.
     """
 
-    diagnostics: List[DiagnosticFileConfig]
-    fortran_diagnostics: List[FortranFileConfig]
+    diagnostics: List[DiagnosticFileConfig] = dataclasses.field(
+        default_factory=lambda: []
+    )
+    fortran_diagnostics: List[FortranFileConfig] = dataclasses.field(
+        default_factory=lambda: []
+    )
     prephysics: Optional[MachineLearningConfig] = None
     scikit_learn: MachineLearningConfig = MachineLearningConfig()
     nudging: Optional[NudgingConfig] = None

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -38,11 +38,9 @@ class UserConfig:
             diagnostics.
     """
 
-    diagnostics: List[DiagnosticFileConfig] = dataclasses.field(
-        default_factory=lambda: []
-    )
+    diagnostics: List[DiagnosticFileConfig] = dataclasses.field(default_factory=list)
     fortran_diagnostics: List[FortranFileConfig] = dataclasses.field(
-        default_factory=lambda: []
+        default_factory=list
     )
     prephysics: Optional[Union[PrescriberConfig, MachineLearningConfig]] = None
     scikit_learn: MachineLearningConfig = MachineLearningConfig()

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -200,7 +200,9 @@ class TimeLoop(Iterable[Tuple[cftime.DatetimeJulian, Diagnostics]], LoggingMixin
         self._prephysics_only_diagnostic_ml: bool = getattr(
             getattr(config, "prephysics"), "diagnostic_ml", False
         )
-        self._postphysics_only_diagnostic_ml: bool = config.scikit_learn.diagnostic_ml
+        self._postphysics_only_diagnostic_ml: bool = getattr(
+            getattr(config, "scikit_learn"), "diagnostic_ml", False
+        )
         self._tendencies: Tendencies = {}
         self._state_updates: State = {}
 
@@ -243,7 +245,7 @@ class TimeLoop(Iterable[Tuple[cftime.DatetimeJulian, Diagnostics]], LoggingMixin
         return stepper
 
     def _get_postphysics_stepper(self, config: UserConfig) -> Optional[Stepper]:
-        if config.scikit_learn.model:
+        if config.scikit_learn:
             self._log_info("Using MLStepper for postphysics updates")
             model = self._open_model(config.scikit_learn, "_postphysics")
             stepper: Optional[Stepper] = PureMLStepper(model, self._timestep)


### PR DESCRIPTION
Make `UserConfig.scikit_learn` optional. Required some changes to check `if config.scikit_learn` instead of `if config.scikit_learn.model`.

This allowed simplifying the `user_config_from_dict_and_args` function by calling `dacite.from_dict(UserConfig, config_dict)` and then inserting command-line argument overrides and custom defaults.

Resolves #1110.