### PR TITLE
Remove diagnostic_ml flag from global state of time loop

### DIFF
--- a/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/machine_learning.py
@@ -204,7 +204,7 @@ class PureMLStepper:
 
         state_updates = {}
 
-        if diagnostic_ml:
+        if self.diagnostic_ml:
             rename_diagnostics(diagnostics)
             tendency = {}
 

--- a/workflows/prognostic_c48_run/tests/test_machine_learning.py
+++ b/workflows/prognostic_c48_run/tests/test_machine_learning.py
@@ -26,10 +26,10 @@ def ml_stepper(ml_stepper_name):
     timestep = 900
     if ml_stepper_name == "PureMLStepper":
         mock_model = get_mock_sklearn_model("tendencies")
-        ml_stepper = PureMLStepper(mock_model, timestep)
+        ml_stepper = PureMLStepper(mock_model, timestep, False)
     elif ml_stepper_name == "MLStateStepper":
         mock_model = get_mock_sklearn_model("rad_fluxes")
-        ml_stepper = MLStateStepper(mock_model, timestep)
+        ml_stepper = MLStateStepper(mock_model, timestep, False)
     return ml_stepper
 
 


### PR DESCRIPTION
This PR removes dependence between steps of time loop by isolating the `diagnostic_ml` flag to the Stepper making the relevant predictions.

Significant internal changes:
- deleted `self._prephysics_only_diagnostic_ml` and `self._postphysics_only_diagnostic_ml` from TimeLoop class
- added `diagnostic_ml` flag for `PureMLStepper` class