### PR TITLE
force a rebuild of vcm when making environment

### DIFF
--- a/.environment-scripts/install_local_packages.sh
+++ b/.environment-scripts/install_local_packages.sh
@@ -4,6 +4,11 @@ CONDA_ENV=$1
 
 source activate $CONDA_ENV
 
+# we want to force a rebuild in case numpy version changes
+# this doesn't rebuild automatically when dependencies change version
+rm external/vcm/vcm/mappm.*.so
+rm -r external/vcm/build
+
 local_packages_to_install=( 
   external/vcm
   external/loaders

--- a/.environment-scripts/install_local_packages.sh
+++ b/.environment-scripts/install_local_packages.sh
@@ -6,8 +6,8 @@ source activate $CONDA_ENV
 
 # we want to force a rebuild in case numpy version changes
 # this doesn't rebuild automatically when dependencies change version
-rm external/vcm/vcm/mappm.*.so
-rm -r external/vcm/build
+rm -f external/vcm/vcm/mappm.*.so
+rm -rf external/vcm/build
 
 local_packages_to_install=( 
   external/vcm

--- a/.environment-scripts/install_local_packages.sh
+++ b/.environment-scripts/install_local_packages.sh
@@ -6,7 +6,7 @@ source activate $CONDA_ENV
 
 # we want to force a rebuild in case numpy version changes
 # this doesn't rebuild automatically when dependencies change version
-rm -f external/vcm/vcm/mappm.*.so
+rm -f "external/vcm/vcm/mappm.*.so"
 rm -rf external/vcm/build
 
 local_packages_to_install=( 


### PR DESCRIPTION
Currently vcm will not rebuild its compiled components if dependencies change. This PR cleans the build artifacts before installing vcm when using `install_local_packages.sh`, to ensure vcm is compatible with the installed version of numpy.

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).