### PR TITLE
Use inner join when merging nudge-to-fine state and tendencies

### DIFF
--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -145,6 +145,7 @@ def open_nudge_to_fine(
                 "state_after_timestep.zarr",
             ],
             consolidated=consolidated,
+            join="inner",
         ).values()
     )
 

--- a/external/loaders/loaders/mappers/_nudged/_nudged.py
+++ b/external/loaders/loaders/mappers/_nudged/_nudged.py
@@ -145,8 +145,8 @@ def open_nudge_to_fine(
                 "state_after_timestep.zarr",
             ],
             consolidated=consolidated,
-            join="inner",
-        ).values()
+        ).values(),
+        join="inner",
     )
 
     differenced_state: Dataset = {}


### PR DESCRIPTION
See issue here: https://github.com/VulcanClimateModeling/fv3net/issues/1004

When the state and tendencies datasets from nudging runs are saved at different frequencies, the nudged-to-fine mapper keys can have empty data for some of the variables because the datasets are outer joined on time. This could lead to overestimating the size of training and test datasets, because some fraction of the timesteps used may be discarded due to NaNs existing in the samples. Since we are now using averaged nudging tendencies for all the nudged runs, this is a common issue in our data.

This PR changes the merge to use an inner join, so that mapper keys only exist for timesteps that the state, nudging tendencies, and physics tendencies are all saved at.

Resolves #<https://github.com/VulcanClimateModeling/fv3net/issues/1004> 

