### PR TITLE
Fix dropping of non-predicted dQ1/2 related variables

### DIFF
--- a/workflows/offline_ml_diags/offline_ml_diags/create_report.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/create_report.py
@@ -110,11 +110,9 @@ if __name__ == "__main__":
 
     # diagnostics_utils currently fill dQ1/2 with zeros if not predicted
     # exclude these from the report if they are not model outputs.
-    print(ds_diags)
     ds_diags = drop_temperature_humidity_tendencies_if_not_predicted(
         ds_diags, config["output_variables"]
     )
-    print(ds_diags)
     ds_diurnal = drop_temperature_humidity_tendencies_if_not_predicted(
         ds_diurnal, config["output_variables"]
     )

--- a/workflows/offline_ml_diags/offline_ml_diags/create_report.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/create_report.py
@@ -5,7 +5,6 @@ import logging
 import sys
 import tempfile
 from typing import MutableMapping, Sequence, List
-import xarray as xr
 
 import fv3viz
 import numpy as np


### PR DESCRIPTION
The last PR that enabled 2D variables in the offline diags had a  bug in the part that dropped dQ1/2 related variables from the offline report if they weren't predicted by the ML model. This fixes it and adds tests.

Testing all possible combinations of outputs:

2D and 3D outputs
https://storage.googleapis.com/vcm-ml-public/annak/2021-03-31-offline-diags/combined-dims-output/index.html

3D outputs only
https://storage.googleapis.com/vcm-ml-public/annak/2021-03-31-offline-diags/tq/index.html

Only one 3D output, should drop the other from the report
https://storage.googleapis.com/vcm-ml-public/annak/2021-03-31-offline-diags/sklearn_dQ1_model/index.html

2D outputs only
https://storage.googleapis.com/vcm-ml-public/annak/2021-03-31-offline-diags/sfc_flux/index.html


- [x ] Tests added
 