### PR TITLE
Remove FRE-NCtools submodule, use GFDL version instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "external/fv3gfs-util"]
 	path = external/fv3gfs-util
 	url = git@github.com:VulcanClimateModeling/fv3gfs-util.git
-[submodule "external/FRE-NCtools"]
-	path = external/FRE-NCtools
-	url = git@github.com:VulcanClimateModeling/FRE-NCtools.git

--- a/docker/post_process_run/Dockerfile
+++ b/docker/post_process_run/Dockerfile
@@ -20,10 +20,16 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     python3-pip
 
-# install FRE-NCtools including fregrid
-COPY external/FRE-NCtools /FRE-NCtools
-RUN cd FRE-NCtools && export CFLAGS=-Wno-traditional NETCDF_LDFLAGS=-lm && \
-    \autoreconf -i && ./configure && make && make install
+# install FRE-NCtools including fregrid. Ideally we would download a
+# tarball of the latest versioned tag (v2.18.0) but v2.18.0 fails
+# to build whereas this more recent commit is successful.
+RUN git config --global http.sslverify false && \
+    git clone https://github.com/NOAA-GFDL/FRE-NCtools.git && \
+    cd FRE-NCtools && \
+    git checkout f5d700467f100b63bf5bf92d69c76be989dd2924 && \
+    export CFLAGS=-Wno-traditional NETCDF_LDFLAGS=-lm && \
+    \autoreconf -i && ./configure && make && make install && \
+    cd .. && rm -r FRE-NCtools
 
 # install gcloud
 RUN apt-get update && apt-get install -y  apt-transport-https ca-certificates gnupg curl gettext

--- a/docker/post_process_run/Dockerfile
+++ b/docker/post_process_run/Dockerfile
@@ -28,7 +28,7 @@ RUN git config --global http.sslverify false && \
     cd FRE-NCtools && \
     git checkout f5d700467f100b63bf5bf92d69c76be989dd2924 && \
     export CFLAGS=-Wno-traditional NETCDF_LDFLAGS=-lm && \
-    \autoreconf -i && ./configure && make && make install && \
+    autoreconf -i && ./configure && make && make install && \
     cd .. && rm -r FRE-NCtools
 
 # install gcloud


### PR DESCRIPTION
It is extra work to maintain our own fork of the FRE-NCtools repo. This PR makes the `post_process_run` Docker image build the FRE-NCtools by cloning the GFDL version of the repo instead of using our version of the repo as a submodule. The submodule is also deleted.

Note the `fregrid` tool is tested by the `fv3post` tests during the Docker build, so I'm confident the install worked as expected.

Resolves #1137 