### PR TITLE
save fine resolution budget to zarr

### DIFF
--- a/.environment-scripts/install_local_packages.sh
+++ b/.environment-scripts/install_local_packages.sh
@@ -14,6 +14,7 @@ local_packages_to_install=(
   external/loaders
   external/fv3fit
   external/fv3gfs-util
+  external/xpartition
 )
 set -e
 for package  in "${local_packages_to_install[@]}"

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test_prognostic_run_report:
 test_%:
 	cd external/$* && tox
 
-test_unit: test_fv3kube test_vcm test_fv3fit
+test_unit: test_fv3kube test_vcm test_fv3fit test_xpartition
 	coverage run -m pytest -m "not regression" --mpl --mpl-baseline-path=tests/baseline_images
 
 test_regression:

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ test_prognostic_run_report:
 test_%:
 	cd external/$* && tox
 
+test_xpartition:
+	cd external/xpartition && tox -e py37
+
 test_unit: test_fv3kube test_vcm test_fv3fit test_xpartition
 	coverage run -m pytest -m "not regression" --mpl --mpl-baseline-path=tests/baseline_images
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -242,7 +242,7 @@ websocket-client==0.57.0
 werkzeug==1.0.1
 wheel==0.35.1
 wrapt==1.12.1
-xarray==0.16.0
+xarray==0.16.2
 xgcm==0.3.0
 xmltodict==0.12.0
 yarl==1.6.3

--- a/external/xpartition/LICENSE
+++ b/external/xpartition/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Spencer Clark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external/xpartition/README.md
+++ b/external/xpartition/README.md
@@ -1,0 +1,147 @@
+# xpartition
+
+[![PyPI](https://img.shields.io/pypi/v/xpartition.svg)](https://pypi.python.org/pypi/xpartition/)
+
+This is a tool that can make writing large xarray datasets to cohesive zarr
+stores from completely independent processes easier.
+
+## Usage
+
+The primary use-case for this is something like this.  Say you have a lot of
+netCDF files output from a simulation or observational dataset that you would
+like to stitch together into a zarr store.  If you have a way of combining
+those files lazily -- i.e. opening them into dask-backed arrays -- into a
+single dataset, then you can write contiguous "partitions" of that dataset out
+via independent processes.  A "partition" corresponds to a contiguous group of
+dask "chunks." I.e. it can correspond to one or more chunks across any number
+of dimensions.  A key detail is no partition straddles any dask chunks; this
+makes writing from independent processes completely safe.
+
+`xpartition` provides an accessor called `partition` that implements
+`initialize_store` and `write` methods.  The pattern is to have some function
+that constructs the dataset lazily, then call `initialize_store`, and finally
+in a set of separate processes, call `write`.
+
+The process might look something like this.  Assume through some external
+package we have a function that can construct a dataset lazily.  Let's write a
+couple command-line interfaces that initialize the store and write a
+partition.  We'll start with one called `initialize_store.py`:
+
+```python
+import argparse
+import xpartition
+
+from external import construct_lazy_dataset
+
+parser.add_argument("store", help="absolute path to directory to store zarr result")
+ds = construct_lazy_dataset()
+ds.partition.initialize_store(args.store)
+```
+
+Next we'll write one called `write_partition.py`:
+
+```python
+import argparse
+import xpartition
+
+from external import construct_lazy_dataset
+
+
+parser.add_argument("store", help="absolute path to directory to store zarr result")
+parser.add_argument("ranks", type=int, help="total number of available ranks")
+parser.add_argument("rank", type=int, help="rank of job")
+
+args = parser.parse_args()
+
+# xpartition uses these as the dimensions to partition the jobs over.
+dims = ["tile", "time"]
+
+ds = construct_lazy_dataset()
+ds.partition.write(args.store, args.ranks, dims, args.rank)
+```
+
+Now let's write a couple bash scripts.  The first will be a SLURM array job
+that writes all the partitions.  The second will be a "main" script that
+controls the whole workflow.
+
+We call this one `write_partition.sh`:
+
+```
+#!/bin/bash
+#SBATCH --job-name=zarr-history-files-array-job
+#SBATCH --output=stdout/slurm-%A.%a.out # STDOUT file
+#SBATCH --error=stdout/slurm-%A.%a.err  # STDERR file
+#SBATCH --time=16:00:00          # total run time limit (HH:MM:SS)
+#SBATCH --array=0-15             # job array with index values 0, 1, 2, ... 15
+
+echo "My SLURM_ARRAY_JOB_ID is $SLURM_ARRAY_JOB_ID."
+echo "My SLURM_ARRAY_TASK_ID is $SLURM_ARRAY_TASK_ID."
+
+STORE=$1
+RANKS=16
+RANK=$SLURM_ARRAY_TASK_ID
+
+python write_partition.py $STORE $RANKS $RANK
+```
+
+And we call this one `write_zarr.sh`:
+
+```
+#!/bin/bash
+set -e
+
+STORE=$1
+
+python initialize_store.py $STORE
+
+# Make a local directory for the stdout and stderr of the array jobs so that
+# they do not clutter up the local space.
+mkdir -p stdout
+
+# Submit the array job with the -W argument to sbatch; this tells SLURM to wait
+# until all array jobs have completed before returning from this script.
+sbatch -W write_partition.sh $STORE
+```
+
+Submitting the full task as is then as simple as:
+
+```
+bash write_zarr.sh /path/to/store.zarr
+```
+
+## Motivation
+
+It is not always advantageous to let all computations be controlled by a single
+dask client.  At the moment, the dask scheduler breaks down when having to
+manage a large number of memory-intensive tasks, often leading to slowdowns or
+out of memory errors (see [this
+issue](https://github.com/dask/distributed/issues/2602) for more discussion).
+Breaking the problem down in the way that `xpartition` does, allows you to gain
+the benefits of dask's laziness on each independent process, while working in a
+distributed environment.  *In an ideal world we wouldn't need a package like
+this -- we would let dask and dask distributed handle everything -- but in
+practice that does not work perfectly yet.*
+
+## Installation
+
+`xpartition` can either be installed from PyPI:
+
+```
+$ pip install xpartition
+```
+
+or directly from source:
+
+```
+$ git clone https://github.com/spencerkclark/xpartition.git
+$ cd xpartition
+$ pip install -e .
+```
+
+## See also
+
+There is some overlap between what this package does and what other libraries
+do, namely packages like:
+
+- [rechunker](https://github.com/pangeo-data/rechunker)
+- [pangeo-forge](https://github.com/pangeo-forge/pangeo-forge)

--- a/external/xpartition/setup.cfg
+++ b/external/xpartition/setup.cfg
@@ -1,0 +1,58 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+
+[metadata]
+name = xpartition
+version = attr: xpartition.__version__
+author = Spencer K. Clark
+author_email = spencerkclark@gmail.com
+license = MIT License
+description = Tool for writing large xarray datasets to zarr stores with independent processes
+long_description =
+    xpartition provides a way to split N-dimensional dask-backed arrays into
+    a user-specified number of blocks of dask chunks.  This can be useful for
+    assigning work to batch jobs on HPC systems or Dataflow workers in an
+    Apache Beam pipeline in the cloud.
+long_description_content_type = text/plain
+url = https://github.com/spencerkclark/xpartition
+classifiers = 
+	Development Status :: 2 - Pre-Alpha
+	License :: OSI Approved :: MIT License
+	Operating System :: OS Independent
+	Intended Audience :: Science/Research
+	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Topic :: Scientific/Engineering
+
+[options]
+packages = find:
+py_modules = xpartition
+zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
+include_package_data = True
+python_requires = >=3.6
+install_requires = 
+	xarray >= 0.16.2
+	dask[array] >= 2.9.0
+	setuptools >= 38.4  # For pkg_resources
+	dataclasses; python_version == "3.6"
+	zarr
+setup_requires = 
+	setuptools >= 38.4
+	setuptools_scm
+
+[flake8]
+ignore = 
+	E203 # whitespace before ':' - doesn't work well with black
+	E402 # module level import not at top of file
+	E501 # line too long - let black worry about that
+	E731 # do not assign a lambda expression, use a def
+	W503 # line break before binary operator
+exclude = 
+	.eggs
+	doc
+
+[bumpversion:file:xpartition.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/external/xpartition/setup.py
+++ b/external/xpartition/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(use_scm_version={"fallback_version": "999"})

--- a/external/xpartition/test_xpartition.py
+++ b/external/xpartition/test_xpartition.py
@@ -1,0 +1,191 @@
+import multiprocessing
+import os
+import string
+
+import pytest
+import numpy as np
+import xarray as xr
+
+import xpartition
+
+
+def _construct_dataarray(shape, chunks, name):
+    dims = list(string.ascii_lowercase[: len(shape)])
+    data = np.random.random(shape)
+    da = xr.DataArray(data, dims=dims, name=name)
+    if chunks is not None:
+        chunks = {dim: chunk for dim, chunk in zip(dims, chunks)}
+        da = da.chunk(chunks)
+    return da
+
+
+SHAPE_AND_CHUNK_PAIRS = [
+    ((5,), (1,)),
+    ((5,), (2,)),
+    ((5,), (5,)),
+    ((2, 5), (1, 1)),
+    ((2, 5), (2, 1)),
+    ((2, 5), (2, 2)),
+    ((2, 5), (2, 4)),
+    ((2, 5), (2, 5)),
+    ((2, 1, 6), (1, 1, 1)),
+    ((2, 1, 6), (1, 1, 2)),
+    ((2, 1, 6), (2, 1, 2)),
+    ((2, 1, 6), (2, 1, 5)),
+    ((2, 3, 4, 5), (1, 1, 1, 1)),
+    ((2, 3, 4, 5), (2, 1, 3, 3)),
+]
+
+
+@pytest.fixture(params=SHAPE_AND_CHUNK_PAIRS, ids=lambda x: str(x))
+def da(request):
+    shape, chunks = request.param
+    name = "foo"
+    return _construct_dataarray(shape, chunks, name)
+
+
+def test_block_indices(da):
+    blocks = xpartition.block_indices(da)
+    blocks_shape = tuple(blocks.sizes[dim] for dim in da.dims)
+    stacked_blocks = blocks.stack(block=[dim for dim in da.dims])
+    for i in range(stacked_blocks.sizes["block"]):
+        indexers = xpartition.block_to_slices(stacked_blocks.isel(block=i))
+        dask_blocks_indices = np.unravel_index(i, blocks_shape)
+        block_data_via_xarray = da.isel(indexers).data.compute()
+        block_data_via_dask = da.data.blocks[dask_blocks_indices].compute()
+        np.testing.assert_array_equal(block_data_via_xarray, block_data_via_dask)
+
+
+@pytest.mark.parametrize(
+    "subset",
+    [
+        {"a": slice(0, 1), "b": slice(0, 1), "c": slice(0, 1), "d": slice(0, 1)},
+        {"a": slice(0, 2), "b": slice(0, 1), "c": slice(0, 1), "d": slice(0, 1)},
+        {"a": slice(0, 1), "b": slice(0, 2), "c": slice(0, 1), "d": slice(0, 1)},
+        {"a": slice(0, 1), "b": slice(0, 1), "c": slice(0, 2), "d": slice(0, 1)},
+        {"a": slice(0, 1), "b": slice(0, 1), "c": slice(0, 1), "d": slice(0, 2)},
+        {"a": slice(1, 2), "b": slice(1, 2), "c": slice(1, 2), "d": slice(1, 2)},
+        {"a": slice(0, 3), "b": slice(0, 1), "c": slice(1, 2), "d": slice(1, 2)},
+        {"a": slice(0, 3), "b": slice(0, 2), "c": slice(0, 1), "d": slice(0, 2)},
+        {"a": slice(0, 4), "b": slice(0, 2), "c": slice(0, 2), "d": slice(0, 2)},
+    ],
+    ids=lambda x: str(x),
+)
+def test_merge_blocks(subset):
+    shape = (4, 3, 2, 7)
+    chunks = (1, 2, 1, 5)
+    dims = list(string.ascii_lowercase[: len(shape)])
+    chunks = {dim: chunk for dim, chunk in zip(dims, chunks)}
+    data = np.random.random(shape)
+    da = xr.DataArray(data, dims=dims, name="foo").chunk(chunks)
+
+    blocks = xpartition.block_indices(da)
+    blocks_subset = blocks.isel(subset)
+    merged_block = xpartition.merge_blocks(blocks_subset, da.dims)
+    merged_block = xpartition.block_to_slices(merged_block)
+    xarray_subset = da.isel(merged_block).data.compute()
+    dask_subset = da.data.blocks[tuple(s for s in subset.values())].compute()
+
+    np.testing.assert_array_equal(xarray_subset, dask_subset)
+
+
+@pytest.mark.filterwarnings("ignore:Specified Dask chunks")
+@pytest.mark.parametrize("ranks", [1, 2, 3, 5, 10, 11])
+def test_dataarray_mappable_write(tmpdir, da, ranks):
+    store = os.path.join(tmpdir, "test.zarr")
+    ds = da.to_dataset()
+    ds.to_zarr(store, compute=False)
+
+    with multiprocessing.get_context("spawn").Pool(ranks) as pool:
+        pool.map(da.partition.mappable_write(store, ranks, da.dims), range(ranks))
+
+    result = xr.open_zarr(store)
+    xr.testing.assert_identical(result, ds)
+
+
+ALIGNED_SHAPE_AND_CHUNK_PAIRS = [
+    ((5,), (1,)),
+    ((5,), (2,)),
+    ((5,), (5,)),
+    ((5, 2), (1, 1)),
+    ((5, 2), (1, 2)),
+    ((5, 2), (2, 2)),
+    ((5, 2), (4, 2)),
+    ((5, 2), (5, 2)),
+    ((5, 2, 6), (1, 1, 1)),
+    ((5, 2, 6), (1, 1, 2)),
+    ((5, 2, 6), (2, 1, 2)),
+    ((5, 2, 6), (2, 2, 5)),
+]
+
+
+@pytest.fixture
+def ds():
+    unchunked_dataarrays = []
+    for i, (shape, chunks) in enumerate(ALIGNED_SHAPE_AND_CHUNK_PAIRS):
+        da = _construct_dataarray(shape, None, f"unchunked_{i}")
+        unchunked_dataarrays.append(da)
+
+    chunked_dataarrays = []
+    for i, (shape, chunks) in enumerate(ALIGNED_SHAPE_AND_CHUNK_PAIRS):
+        da = _construct_dataarray(shape, chunks, f"chunked_{i}")
+        chunked_dataarrays.append(da)
+
+    return xr.merge(unchunked_dataarrays + chunked_dataarrays)
+
+
+@pytest.mark.filterwarnings("ignore:Specified Dask chunks")
+@pytest.mark.parametrize("ranks", [1, 2, 3, 5, 10, 11])
+def test_dataset_mappable_write(tmpdir, ds, ranks):
+    store = os.path.join(tmpdir, "test.zarr")
+    ds.partition.initialize_store(store)
+
+    with multiprocessing.get_context("spawn").Pool(ranks) as pool:
+        pool.map(ds.partition.mappable_write(store, ranks, ds.dims), range(ranks))
+
+    result = xr.open_zarr(store)
+    xr.testing.assert_identical(result, ds)
+
+
+@pytest.mark.parametrize("has_coord", [True, False])
+def test_PartitionMapper_integration(tmpdir, has_coord):
+    def func(ds):
+        return ds.rename(z="new_name").assign_attrs(dataset_attr="fun")
+
+    ds = xr.Dataset({"z": (["x", "y"], np.ones((5, 10)), {"an": "attr"})},).chunk(
+        {"x": 2}
+    )
+    if has_coord:
+        ds = ds.assign_coords(x=range(5))
+
+    store = str(tmpdir)
+    mapper = ds.z.partition.map(store, ranks=3, dims=["x"], func=func, data=ds)
+    for rank in mapper:
+        mapper.write(rank)
+
+    written = xr.open_zarr(store)
+    xr.testing.assert_identical(func(ds), written)
+
+
+def test_partition_partition():
+    # Partitions have two qualities which we test using a DataArray that
+    # has all unique values
+    ds = xr.Dataset({"z": (["x", "y"], np.arange(50).reshape((5, 10)))}).chunk({"x": 2})
+    arr = ds["z"]
+
+    n = 3
+    regions = arr.partition.partition(n, dims=["x"])
+    assert n == len(regions)
+
+    def to_set(arr):
+        return set(arr.values.ravel().tolist())
+
+    # These are the properties of a partition
+    # 1. sets in a partition are disjoint
+    intersection = set.intersection(*[to_set(arr.isel(region)) for region in regions])
+    assert intersection == set()
+
+    # assert that the values cover the set
+    # 2. the sets cover the original set
+    union = set.union(*[to_set(arr.isel(region)) for region in regions])
+    assert union == to_set(arr)

--- a/external/xpartition/tox.ini
+++ b/external/xpartition/tox.ini
@@ -1,0 +1,23 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36, py37
+
+[testenv]
+deps = 
+    pytest
+commands =
+    pytest -vv
+
+[testenv:lint]
+skip_install = true
+deps =
+    black==19.10b0
+    flake8==3.7.9
+commands = 
+    black --check .
+    flake8 *.py
+

--- a/external/xpartition/xpartition.py
+++ b/external/xpartition/xpartition.py
@@ -1,0 +1,371 @@
+import functools
+import math
+
+import dask.array
+import numpy as np
+import pandas as pd
+import xarray as xr
+import dataclasses
+import logging
+
+from typing import Callable, Dict, Hashable, List, Sequence, Tuple, Mapping
+
+
+__version__ = "0.1.0"
+
+
+DIMENSION_DIM = "dimension"
+SLICE_BOUND_DIM = "slice_bound"
+SLICE_BOUND_INDEX = pd.Index(["start", "stop"], name=SLICE_BOUND_DIM)
+AUXILLARY_DIMENSIONS = [DIMENSION_DIM, SLICE_BOUND_DIM]
+
+Region = Sequence[Mapping[Hashable, slice]]
+Partition = Sequence[Region]
+
+
+def _chunks_as_data_arrays(da: xr.DataArray) -> xr.Dataset:
+    chunks = da.chunks
+    arrays = []
+    for dim, chunks in zip(da.dims, da.chunks):
+        arrays.append(xr.DataArray(list(chunks), dims=[dim], name=f"{dim}_chunks"))
+    return xr.merge(arrays)
+
+
+def _block_starts(da: xr.DataArray) -> List[xr.DataArray]:
+    chunks_as_data_arrays = _chunks_as_data_arrays(da)
+    stops = _block_stops(da)
+    return [stop - a for stop, a in zip(stops, chunks_as_data_arrays.values())]
+
+
+def _block_stops(da: xr.DataArray) -> List[xr.DataArray]:
+    chunks_as_data_arrays = _chunks_as_data_arrays(da)
+    return [a.cumsum(a.dims) for a in chunks_as_data_arrays.values()]
+
+
+def block_indices(da: xr.DataArray) -> xr.DataArray:
+    """Generate an array of dask array block bounds for a DataArray.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+
+    Returns
+    -------
+    xr.DataArray
+    """
+    starts = _block_starts(da)
+    stops = _block_stops(da)
+    dimension_index = pd.Index(da.dims, name=DIMENSION_DIM)
+    starts = xr.concat(xr.broadcast(*starts), dim=dimension_index)
+    stops = xr.concat(xr.broadcast(*stops), dim=dimension_index)
+    result = xr.concat([starts, stops], dim=SLICE_BOUND_INDEX)
+
+    # Put auxillary dimensions at the end to make it easier to select
+    # contiguous slices.
+    return result.transpose(*dimension_index, ...)
+
+
+def block_to_slices(block: xr.DataArray) -> Dict[Hashable, slice]:
+    """Convert a DataArray representing a single block to a dictionary of slices.
+
+    Parameters
+    ----------
+    block : xr.DataArray
+
+    Returns
+    -------
+    Dictionary mapping dimension names to slices.
+    """
+    slices = {}
+    for dim in block.dimension:
+        start = block.sel({SLICE_BOUND_DIM: "start", DIMENSION_DIM: dim}).item()
+        stop = block.sel({SLICE_BOUND_DIM: "stop", DIMENSION_DIM: dim}).item()
+        slices[dim.item()] = slice(start, stop)
+    return slices
+
+
+def merge_blocks(blocks: xr.DataArray, dims: Sequence[Hashable]):
+    """Merge a DataArray of blocks into a single block.
+
+    Parameters
+    ----------
+    blocks : xr.DataArray
+        An input array of blocks; must have dimensions "slice_bound"
+        and "dimension".
+    dims : Sequence[Hashable]
+        Dimensions to merge blocks along.
+
+    Notes
+    -------
+    Assumes that the input blocks are contiguous.
+
+    Returns
+    -------
+    xr.DataArray for a single merged block.
+    """
+    start = blocks.isel({dim: 0 for dim in dims}).sel({SLICE_BOUND_DIM: "start"})
+    stop = blocks.isel({dim: -1 for dim in dims}).sel({SLICE_BOUND_DIM: "stop"})
+    return xr.concat([start, stop], dim=SLICE_BOUND_INDEX)
+
+
+def _scalars_to_slices(kwargs):
+    result = {}
+    for k, v in kwargs.items():
+        if isinstance(v, slice):
+            result[k] = v
+        elif np.issubdtype(v, np.integer):
+            result[k] = slice(v, v + 1)
+        else:
+            raise ValueError(f"Invalid indexer provided for dim {k}: {v}.")
+    return result
+
+
+@xr.register_dataarray_accessor("blocks")
+class BlocksAccessor:
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+        if not isinstance(self._obj.data, dask.array.Array):
+            raise ValueError(
+                "The blocks accessor is only valid for dask-backed arrays."
+            )
+
+    @property
+    def _blocks(self) -> xr.DataArray:
+        return block_indices(self._obj)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return tuple(len(c) for c in self._obj.chunks)
+
+    @property
+    def sizes(self) -> Dict[Hashable, int]:
+        return {dim: size for dim, size in zip(self._obj.dims, self.shape)}
+
+    def indexers(self, **kwargs) -> Region:
+        kwargs = _scalars_to_slices(kwargs)
+        blocks = self._blocks.isel(**kwargs)
+        merged = merge_blocks(blocks, self._obj.dims)
+        return block_to_slices(merged)
+
+    def isel(self, **kwargs) -> xr.DataArray:
+        slices = self.indexers(**kwargs)
+        # TODO: should we squeeze out dimensions where scalars were passed?
+        return self._obj.isel(slices)
+
+
+def _write_partition_dataarray(
+    da: xr.DataArray, store: str, ranks: int, dims: Sequence[Hashable], rank: int
+):
+    ds = da.to_dataset()
+    partition = da.partition.indexers(ranks, rank, dims)
+    if partition is not None:
+        ds.isel(partition).to_zarr(store, region=partition)
+
+
+def _write_partition_dataset(
+    ds: xr.Dataset, store: str, ranks: int, dims: Sequence[Hashable], rank: int
+):
+    for da in ds.data_vars.values():
+        if isinstance(da.data, dask.array.Array):
+            partition_dims = [dim for dim in dims if dim in da.dims]
+            da.partition.write(store, ranks, partition_dims, rank)
+
+
+@xr.register_dataarray_accessor("partition")
+class PartitionDataArrayAccessor:
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+        if not isinstance(self._obj.data, dask.array.Array):
+            raise ValueError(
+                "The partition accessor is only valid for dask-backed arrays."
+            )
+
+    def _meta_array(self, chunks: Dict[Hashable, int]) -> xr.DataArray:
+        dummy_data = dask.array.zeros(self._obj.blocks.shape)
+        da = xr.DataArray(dummy_data, dims=self._obj.dims, name="blocks")
+        return da.chunk(chunks)
+
+    def _optimal_meta_chunk_sizes(
+        self, ranks: int, dims: Sequence[Hashable]
+    ) -> Dict[Hashable, int]:
+        """Determine the optimal meta chunk sizes for the DataArray.
+
+        Partitions are prioritized based on the ordering of the dims
+        provided.  Priority means we will first make the meta chunk
+        size one along those dimensions before moving to larger meta
+        chunk sizes.
+
+        Parameters
+        ----------
+        ranks : int
+            Total number of ranks available to partition across.
+        dims : Sequence[Hashable]
+            Dimensions to partition among; if a dimension is left out
+            no partitions will be made along that dimension.
+
+        Returns
+        -------
+        Dict[Hashable, int]
+        """
+        chunk_sizes = {}
+        for dim in dims:
+            block_sizes = []
+            for d, s in chunk_sizes.items():
+                block_size = math.ceil(self._obj.blocks.sizes[d] / s)
+                block_sizes.append(block_size)
+            blocks = np.product(block_sizes)
+            size = math.ceil(self._obj.blocks.sizes[dim] / (ranks // blocks))
+            chunk_sizes[dim] = min(size, self._obj.blocks.sizes[dim])
+        return chunk_sizes
+
+    def partition(self, ranks, dims) -> Partition:
+        """Compute a ranks-sized partition respecting dask block boundaries
+
+        Parameters
+        ----------
+        ranks : int
+            Total number of ranks available to partition across.
+        dims : Sequence[Hashable]
+            Dimensions to partition among; if a dimension is left out
+            no partitions will be made along that dimension.
+
+        Returns
+        -------
+        a list of disjoint regions whose union is the full coordinate space
+        """
+        return [self.indexers(ranks, rank, dims) for rank in range(ranks)]
+
+    def indexers(self, ranks: int, rank: int, dims: Sequence[Hashable]) -> Region:
+        """Partition the dask blocks across the given dims.
+
+        Parameters
+        ----------
+        ranks : int
+            Total number of ranks available to partition across.
+        rank : int
+            Specific rank to obtain the indexers for.
+        dims : Sequence[Hashable]
+            Dimensions to partition among; if a dimension is left out
+            no partitions will be made along that dimension.
+
+        Returns
+        -------
+        Dict[Hashable, slice]
+        """
+        if (rank - 1) > ranks:
+            raise ValueError(f"Rank {rank} is greater than available ranks {ranks}.")
+
+        meta_chunk_sizes = self._optimal_meta_chunk_sizes(ranks, dims)
+        meta_array = self._meta_array(meta_chunk_sizes)
+        try:
+            meta_indices = np.unravel_index(rank, meta_array.blocks.shape)
+        except ValueError:
+            return None
+        else:
+            meta_indexers = dict(zip(meta_array.dims, meta_indices))
+            dask_indexers = meta_array.blocks.indexers(**meta_indexers)
+            return self._obj.blocks.indexers(**dask_indexers)
+
+    def write(self, store: str, ranks: int, dims: Sequence[Hashable], rank: int):
+        _write_partition_dataarray(self._obj, store, ranks, dims, rank)
+
+    def mappable_write(
+        self, store: str, ranks: int, dims: Sequence[Hashable]
+    ) -> Callable[[int], None]:
+        return functools.partial(
+            _write_partition_dataarray, self._obj, store, ranks, dims
+        )
+
+    @property
+    def _chunks(self):
+        return {dim: self._obj.chunks[k] for k, dim in enumerate(self._obj.dims)}
+
+    def map(
+        self, store: str, ranks: int, dims: Sequence[Hashable], func, data
+    ) -> "PartitionMapper":
+        plan = _ValidWorkPlan(self, ranks, dims)
+        return PartitionMapper(plan, func, data, store)
+
+
+@xr.register_dataset_accessor("partition")
+class PartitionDatasetAccessor:
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+
+    def initialize_store(self, store: str):
+        self._obj.to_zarr(store, compute=False)
+
+    def write(self, store: str, ranks: int, dims: Sequence[Hashable], rank: int):
+        _write_partition_dataset(self._obj, store, ranks, dims, rank)
+
+    def mappable_write(
+        self, store: str, ranks: int, dims: Sequence[Hashable]
+    ) -> Callable[[int], None]:
+        return functools.partial(
+            _write_partition_dataset, self._obj, store, ranks, dims
+        )
+
+
+def zeros_like(ds: xr.Dataset, chunks):
+    return xr.zeros_like(ds).chunk(chunks)
+
+
+class _ValidWorkPlan:
+    """A mapping between input and output partitionings that will
+    avoid race conditions in parallel jobs
+    """
+
+    def __init__(self, partitioner, ranks: int, dims: Sequence[Hashable]):
+
+        self._partitioner = partitioner
+        self._ranks = ranks
+        self.dims = dims
+
+    @property
+    def output_chunks(self):
+        return {dim: self._partitioner._chunks[dim] for dim in self.dims}
+
+    @property
+    def input_partition(self):
+        return self._partitioner.partition(self._ranks, self.dims)
+
+
+@dataclasses.dataclass
+class PartitionMapper:
+    """Evaluate a function on each region of a partition and store the output
+    to a zarr store
+    """
+
+    plan: _ValidWorkPlan
+    func: Callable[[xr.Dataset], xr.Dataset]
+    data: xr.Dataset
+    path: str
+
+    @property
+    def dims(self):
+        return self.plan.dims
+
+    def _initialize_store(self):
+        region = self.plan.input_partition[0]
+        iData = self.data.isel(region)
+        iOut = self.func(iData)
+        full_indexers = {dim: self.data[dim] for dim in self.dims}
+
+        dims_without_coords = (set(iOut.dims) - set(iOut.indexes)) & set(self.dims)
+        for dim in dims_without_coords:
+            iOut = iOut.assign_coords({dim: iOut[dim]})
+
+        schema = zeros_like(iOut.reindex(full_indexers), chunks=self.plan.output_chunks)
+        schema = schema.drop_vars(dims_without_coords)
+        schema.partition.initialize_store(self.path)
+
+    def write(self, rank):
+        logging.info(f"Writing {rank + 1} of {len(self.plan.input_partition)}")
+        region = self.plan.input_partition[rank]
+        iData = self.data.isel(region)
+        iOut = self.func(iData)
+        iOut.to_zarr(self.path, region=region)
+
+    def __iter__(self):
+        self._initialize_store()
+        return iter(range(len(self.plan.input_partition)))

--- a/external/xpartition/xpartition.py
+++ b/external/xpartition/xpartition.py
@@ -250,6 +250,7 @@ class PartitionDataArrayAccessor:
         return Map(functools.partial(self._indexers, ranks, dims), list(range(ranks)))
 
     def _indexers(self, ranks, dims, rank):
+        """Needed for creating a partial function within the partition method."""
         return self.indexers(ranks, rank, dims)
 
     def indexers(self, ranks: int, rank: int, dims: Sequence[Hashable]) -> Region:

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -24,6 +24,10 @@ zarr>=2.5.0
 # this version has wheels = faster installs
 numcodecs>=0.7.2
 
+# xpartition needs >=0.16.2 for region feature of to_zarr
+# pip-compile doesn't work with setup.cfg
+xarray >= 0.16.2, <0.17.0 # 0.17 is python37 only, but we usually run pip-compile on 36 :(
+
 # developer tools
 conda-lock
 pip-tools

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ norecursedirs =
     external/fv3gfs-fortran
     external/fv3kube
     external/vcm
+    external/xpartition
     workflows/dataflow/tests/integration
     docker 
     workflows/prognostic_c48_run 

--- a/workflows/dataflow/dataflow.sh
+++ b/workflows/dataflow/dataflow.sh
@@ -12,6 +12,7 @@ vcmPackages=(
   "${ROOT}/workflows/dataflow"
   "${ROOT}/external/vcm"
   "${ROOT}/workflows/fine_res_budget"
+  "${ROOT}/external/xpartition"
 )
 
 function buildSdist {
@@ -41,6 +42,7 @@ function checkInstallation {
   pip install apache_beam
   pip install dists/vcm*.tar.gz
   pip install dists/budget*.tar.gz
+  pip install dists/xpartition*.tar.gz
 }
 
 function runRemote {
@@ -50,6 +52,7 @@ function runRemote {
   --extra_package dists/vcm*.tar.gz \
   --extra_package dists/fv3net*.tar.gz \
   --extra_package dists/budget*.tar.gz \
+  --extra_package dists/xpartition*.tar.gz \
   "
   
   cmd="python $* $packageArgs"

--- a/workflows/dataflow/setup.py
+++ b/workflows/dataflow/setup.py
@@ -14,6 +14,7 @@ dependencies = [
     "numba",
     "cftime==1.1.1.2",
     "vcm",
+    "xpartition",
 ]
 
 setup(

--- a/workflows/fine_res_budget/budget/pipeline.py
+++ b/workflows/fine_res_budget/budget/pipeline.py
@@ -35,8 +35,8 @@ def func(iData):
 
 def open_partitioner(restart_url, physics_url, gfsphysics_url, area_url, output_dir):
     data = open_merged(restart_url, physics_url, gfsphysics_url, area_url)
-    dims = ["time", "tile"]
-    ranks = len(data.time) * len(data.tile)
+    dims = ["time"]
+    ranks = len(data.time)
     mapper = data.delp.isel(step=0).partition.map(
         fsspec.get_mapper(output_dir), ranks, dims, func, data
     )

--- a/workflows/fine_res_budget/budget/pipeline.py
+++ b/workflows/fine_res_budget/budget/pipeline.py
@@ -1,97 +1,61 @@
-import socket
-import datetime
-import sys
-import logging
-from typing import Iterable, Sequence, Hashable, Mapping
-from itertools import product
-import os
-import xarray as xr
-
-import apache_beam as beam
+import apache_beam
 import dask
-from apache_beam.io.filesystems import FileSystems
+import fsspec
+import xpartition  # noqa: E402 F401
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.utils import retry
+from budget import budgets, config
+from budget.data import open_merged
 
 from fv3net.pipelines.common import FunctionSource
-
-import vcm
-
-from . import config
-from . import budgets
-from .data import open_merged
 
 dask.config.set(scheduler="single-threaded")
 
 
-logger = logging.getLogger(__file__)
-
-
-Dims = Sequence[Hashable]
-
-
-def yield_indices(merged: xr.Dataset, dims: Dims) -> Iterable[Mapping[Hashable, slice]]:
-    logger.info("Yielding Indices")
-    indexes = [merged[dim].values.tolist() for dim in dims]  # type: ignore
-    for index in product(*indexes):
-        yield dict(zip(dims, index))
-
-
 @retry.with_exponential_backoff(num_retries=7)
-def save(ds: xr.Dataset, base: str):
-    time = vcm.encode_time(ds.time.item())
-    tile = ds.tile.item()
-
-    path = os.path.join(base, f"{time}.tile{tile}.nc")
-    logger.info(f"saving data to {path}")
-
-    try:
-        FileSystems.mkdirs(base)
-    except IOError:
-        pass
-
-    with FileSystems.create(path) as f:
-        vcm.dump_nc(ds, f)
+def _write(rank, mapper):
+    return mapper.write(rank)
 
 
-class OpenTimeChunks(beam.PTransform):
-    def expand(self, merged):
+class WriteAll(apache_beam.PTransform):
+    def expand(self, mapper):
         return (
-            merged
-            | "YieldPhysicsChunk" >> beam.ParDo(yield_indices, ["time", "tile"])
-            | beam.Reshuffle()
-            | beam.Map(lambda index, ds: ds.sel(index), beam.pvalue.AsSingleton(merged))
+            mapper
+            | apache_beam.ParDo(iter)
+            | apache_beam.Reshuffle()
+            | apache_beam.Map(_write, mapper=apache_beam.pvalue.AsSingleton(mapper))
         )
+
+
+def func(iData):
+    return budgets.compute_recoarsened_budget_inputs(
+        iData, config.factor, first_moments=config.VARIABLES_TO_AVERAGE
+    ).drop(["step"])
+
+
+def open_partitioner(restart_url, physics_url, gfsphysics_url, area_url, output_dir):
+    data = open_merged(restart_url, physics_url, gfsphysics_url, area_url)
+    dims = ["time", "tile"]
+    ranks = len(data.time) * len(data.tile)
+    mapper = data.delp.isel(step=0).partition.map(
+        fsspec.get_mapper(output_dir), ranks, dims, func, data
+    )
+    return mapper
 
 
 def run(restart_url, physics_url, gfsphysics_url, area_url, output_dir, extra_args=()):
 
     options = PipelineOptions(extra_args)
-    with beam.Pipeline(options=options) as p:
-
+    with apache_beam.Pipeline(options=options) as p:
         (
             p
             | FunctionSource(
-                open_merged, restart_url, physics_url, gfsphysics_url, area_url
+                open_partitioner,
+                restart_url,
+                physics_url,
+                gfsphysics_url,
+                area_url,
+                output_dir,
             )
-            | OpenTimeChunks()
-            | "Compute Budget"
-            >> beam.Map(
-                budgets.compute_recoarsened_budget_inputs,
-                factor=config.factor,
-                first_moments=config.VARIABLES_TO_AVERAGE,
-            )
-            | "Insert metadata"
-            >> beam.Map(
-                lambda x: x.assign_attrs(
-                    history=" ".join(sys.argv),
-                    restart_url=restart_url,
-                    physics_url=physics_url,
-                    area_url=area_url,
-                    gfsphysics_url=gfsphysics_url,
-                    launching_host=socket.gethostname(),
-                    date_computed=datetime.datetime.now().isoformat(),
-                )
-            )
-            | "Save" >> beam.Map(save, base=output_dir)
+            | WriteAll()
         )


### PR DESCRIPTION
The folder of netCDFs is inconvenient to analyze

This PR adjusts the fine resolution budget coarse-graining workflow to save to
zarr instead using Spencer's new xpartitioner project.


Requirement changes:
- add xpartitioner as a subtree

- [ ] Tests added

