### PR TITLE
Save offline diags to subdir with item name

### DIFF
--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -73,7 +73,7 @@ spec:
               - name: offline-diags-output
                 value: "{{inputs.parameters.root}}/offline_diags/{{item.name}}"
               - name: report-output
-                value: "{{inputs.parameters.public-report-output}}"
+                value: "{{inputs.parameters.public-report-output}}/{{item.name}}"
               - name: memory
                 value: "{{inputs.parameters.memory-offline-diags}}"
       - name: construct-full-flags


### PR DESCRIPTION
When multiple models are trained using the train-diags-prog template, their individual offline reports should get saved to subdirs in the report output dir. Right now the subdirectories aren't specified in the template offline diags public output step, so the first report to complete is saved to the top level of the public output and the rest are uploaded as tmpdirs with random names into that directory.
