### PR TITLE
fix minor prognostic_run docs issues

### DIFF
--- a/workflows/prognostic_c48_run/docs/config-usage.rst
+++ b/workflows/prognostic_c48_run/docs/config-usage.rst
@@ -170,11 +170,12 @@ to the Fortran ``diag_table`` representation of diagnostics (see fv3config_ docs
 Chunking
 ^^^^^^^^
 
-The desired chunking can be specified for each diagnostic file to be output. For
-segmented runs (:ref:`segmented-run-cli`) there is a requirement that the chunk size
-along the time dimension evenly divide the length of the time dimension for the
-given output. Segmented runs will raise an exception during initialization if this
-requirement is not met.
+The desired chunking can be specified for each diagnostic file to be output. 
+
+.. warning::
+
+    Segmented runs have specific requirements for chunks. See 
+    :ref:`segmented-run-cli` for details.
 
 
 .. _fv3config: https://fv3config.readthedocs.io/en/latest/

--- a/workflows/prognostic_c48_run/docs/configuration-api.rst
+++ b/workflows/prognostic_c48_run/docs/configuration-api.rst
@@ -44,24 +44,20 @@ Python "prephysics and postphysics"
 .. autoclass:: PrescriberConfig
 
 
-Diagnostics
-~~~~~~~~~~~
-
-.. py:module:: runtime.diagnostics.manager
-.. autoclass:: TimeConfig
-
 Python Diagnostics
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 .. py:module:: runtime.diagnostics.manager
 .. autoclass:: DiagnosticFileConfig
+.. autoclass:: TimeConfig
 
 
 Fortran Diagnostics
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 .. py:module:: runtime.diagnostics.fortran
 .. autoclass:: FortranFileConfig
+.. autoclass:: FortranTimeConfig
 .. autoclass:: FortranVariableNameSpec
 
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -23,8 +23,7 @@ class UserConfig:
 
     Attributes:
         diagnostics: list of diagnostic file configurations
-        fortran_diagnostics: list of Fortran diagnostic outputs. Currently only used by
-            post-processing and so only name and chunks items need to be specified.
+        fortran_diagnostics: list of Fortran diagnostic file configurations
         prephysics: optional configuration of computations prior to physics,
             specified by either a machine learning configuation or a prescriber
             configuration


### PR DESCRIPTION
Update incorrect docstring and include a missing dataclass `FortranTimeConfig` in the docs. Also remove some redundant info mistakenly introduced in #1133 .
