### PR TITLE
prog run report: use RunDiagnostics container

### DIFF
--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -3,11 +3,10 @@ import dataclasses
 import io
 import logging
 from collections import defaultdict
-from typing import Iterable, Sequence
+from typing import Sequence
 
 import jinja2
 import matplotlib.pyplot as plt
-import xarray as xr
 from fv3net.diagnostics.prognostic_run.computed_diagnostics import RunDiagnostics
 
 
@@ -53,14 +52,12 @@ template = jinja2.Template(
 
 
 def plot_2d_matplotlib(
-    diagnostics: Iterable[xr.Dataset], varfilter: str, dims: Sequence = None, **opts
+    run_diags: RunDiagnostics, varfilter: str, dims: Sequence = None, **opts
 ) -> str:
     """Plot all diagnostics whose name includes varfilter. Plot is overlaid across runs.
     All matching diagnostics must be 2D and have the same dimensions."""
 
     data = defaultdict(dict)
-
-    run_diags = RunDiagnostics(diagnostics)
 
     # kwargs handling
     ylabel = opts.pop("ylabel", "")

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -94,5 +94,11 @@ def test_RunDiagnostics_runs():
 
 def test_RunDiagnostics_list_variables():
     ds = xarray.Dataset({})
-    diagnostics = RunDiagnostics([ds.assign(a=1, b=1), ds.assign(b=1), ds.assign(c=1)])
+    diagnostics = RunDiagnostics(
+        [
+            ds.assign(a=1, b=1).assign_attrs(run="1"),
+            ds.assign(b=1).assign_attrs(run="2"),
+            ds.assign(c=1).assign_attrs(run="3"),
+        ]
+    )
     assert diagnostics.variables == {"a", "b", "c"}

--- a/workflows/prognostic_run_diags/tests/test_generate_report.py
+++ b/workflows/prognostic_run_diags/tests/test_generate_report.py
@@ -1,17 +1,18 @@
+import uuid
+
+import numpy as np
+import pytest
+import xarray
+from google.cloud.storage.client import Client
+
+from fv3net.diagnostics.prognostic_run.computed_diagnostics import RunDiagnostics
+from fv3net.diagnostics.prognostic_run.views.matplotlib import plot_2d_matplotlib
 from fv3net.diagnostics.prognostic_run.views.static_report import (
-    upload,
     _html_link,
     plot_2d,
+    render_links,
+    upload,
 )
-from fv3net.diagnostics.prognostic_run.views.static_report import render_links
-
-import pytest
-import uuid
-from google.cloud.storage.client import Client
-import xarray
-import numpy as np
-
-from fv3net.diagnostics.prognostic_run.views.matplotlib import plot_2d_matplotlib
 
 
 @pytest.fixture()
@@ -87,7 +88,7 @@ def test_plot_2d(opts, plot_2d):
     )
 
     out = plot_2d(
-        [diagnostics, diagnostics.assign_attrs(run="k")],
+        RunDiagnostics([diagnostics, diagnostics.assign_attrs(run="k")]),
         "somefilter",
         dims=["x", "y"],
         cmap="viridis",


### PR DESCRIPTION
This refactors the plotters to exclusively use RunDiagnostics containers.
This makes the interface of the plotting functions more consistent, and
enables a better separation of concerns.

Improve the performance of RunDiagnostics.get_variable to make this feasible.
My changes caused an error if any of the runs don't have a .run attribute.
This class should not be used with data that doesn't have this attribute
anyway, so I fixed the test data.