### PR TITLE
Bump gcsfs, fsspec and zarr versions

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -57,11 +57,11 @@ fastavro==1.3.0
 fasteners==0.15
 filelock==3.0.12
 flatbuffers==1.12
-fsspec==0.8.5
+fsspec==0.9.0
 future==0.18.2
 fv3config==0.7.1
 gast==0.3.3
-gcsfs==0.7.1
+gcsfs==0.8.0
 google-api-core==1.22.2
 google-apitools==0.5.31
 google-auth-oauthlib==0.4.1
@@ -231,6 +231,7 @@ traitlets==4.3.3
 typeguard==2.10.0
 typing-extensions==3.7.4.3
 typing-inspect==0.6.0
+ujson==4.0.2
 urllib3==1.25.10
 virtualenv==20.0.33
 wcwidth==0.2.5
@@ -244,7 +245,7 @@ xgcm==0.3.0
 xmltodict==0.12.0
 yarl==1.6.3
 yq==2.11.0
-zarr==2.4.0
+zarr==2.7.0
 zipp==3.1.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -18,8 +18,12 @@ tensorflow-addons
 fv3config
 numba
 
-# This version of gcsfs breaks logging
-gcsfs!=0.7.0
+# Hope for more stable performance with these versions
+gcsfs>=0.8.0
+fsspec>=0.9.0
+
+# faster async
+zarr>=2.5.0
 
 # this version has wheels = faster installs
 numcodecs>=0.7.2


### PR DESCRIPTION
Bumping `gcsfs` to 0.8.0 and `fsspec` to 0.9.0 may give more stable performance (#1136). `zarr` has performance improvements in `v2.5.0` that might speed some of our calculations.

Requirement changes:
- in pip-requirements.txt, specify `gcsfs>=0.8.0`, `fsspec>=0.9.0` and `zarr>=2.5.0`