### PR TITLE
add vcm.cubedsphere.to_cross

### DIFF
--- a/external/fv3viz/examples/plot_cross.py
+++ b/external/fv3viz/examples/plot_cross.py
@@ -3,7 +3,8 @@
 ==========================
 
 The routine ``vcm.cubedsphere.to_cross`` is useful for quick plots when
-cartopy may not be installed.
+cartopy may not be installed and/or latitude and longitude coordinates
+are not easily available.
 """
 
 import vcm

--- a/external/fv3viz/examples/plot_cross.py
+++ b/external/fv3viz/examples/plot_cross.py
@@ -1,0 +1,20 @@
+"""
+"Cross" plot
+==========================
+
+The routine ``vcm.cubedsphere.to_cross`` is useful for quick plots when
+cartopy may not be installed.
+"""
+
+import vcm
+import fsspec
+
+url = "https://github.com/VulcanClimateModeling/vcm-ml-example-data/blob/main/fv3net/fv3viz/plot_2_plot_cube_prognostic_diags.nc?raw=true"  # noqa
+fs = fsspec.get_fs_token_paths(url)[0]
+ds = vcm.open_remote_nc(fs, url).load()
+
+cross = vcm.cubedsphere.to_cross(ds["h500_time_mean_value"], x="x", y="y", tile="tile")
+cross.plot.contourf(levels=31)
+
+# need this to avoid hdf5 related error for some reason
+del ds

--- a/external/vcm/docs/grid-operations.rst
+++ b/external/vcm/docs/grid-operations.rst
@@ -1,5 +1,6 @@
-Grid operations
-===============
+Cubed-sphere grid operations
+============================
+
 
 Horizontal coarse-graining
 --------------------------
@@ -48,33 +49,7 @@ that it has the same resolution as the fine grid.
 
    .. automethod:: vcm.cubedsphere.block_upsample
 
+Other
+-----
 
-Interpolation
--------------
-
-General purpose interpolation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-   .. automethod:: vcm.interpolate.interpolate_1d
-   .. automethod:: vcm.interpolate.interpolate_unstructured
-
-
-Interpolating to globally constant pressure levels
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-   .. automethod:: vcm.interpolate.interpolate_to_pressure_levels
-
-
-Interpolation using the vertical remapping algorithm of FV3
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-   .. automethod:: vcm.cubedsphere.regrid_vertical
-
-
-Regional calculations
----------------------
-
-.. automodule:: vcm.select
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. automethod:: vcm.cubedsphere.to_cross

--- a/external/vcm/docs/index.rst
+++ b/external/vcm/docs/index.rst
@@ -22,6 +22,7 @@ It is licensed under a BSD License.
    sampling
    derived-mapping
    grid-operations
+   interpolation
    xarray-io
    xarray-tools
    thermodynamics

--- a/external/vcm/docs/interpolation.rst
+++ b/external/vcm/docs/interpolation.rst
@@ -1,0 +1,29 @@
+Interpolation
+=============
+
+General purpose interpolation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   .. automethod:: vcm.interpolate.interpolate_1d
+   .. automethod:: vcm.interpolate.interpolate_unstructured
+
+
+Interpolating to globally constant pressure levels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   .. automethod:: vcm.interpolate.interpolate_to_pressure_levels
+
+
+Interpolation using the vertical remapping algorithm of FV3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   .. automethod:: vcm.cubedsphere.regrid_vertical
+
+
+Regional calculations
+---------------------
+
+.. automodule:: vcm.select
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/external/vcm/tests/test_cubedsphere.py
+++ b/external/vcm/tests/test_cubedsphere.py
@@ -840,4 +840,4 @@ def test_to_cross(transpose, tile_dim, x_dim, y_dim):
 
     # manually hardcode the hash since it is shared across all parameterize
     # statements
-    assert joblib.hash(one_tile.values) == "77b919b5968584e9de056663979cb60e"
+    assert joblib.hash(one_tile.values) == "04eddd324d0f3150a02499c788ec675d"

--- a/external/vcm/tests/test_cubedsphere.py
+++ b/external/vcm/tests/test_cubedsphere.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 import xgcm
+import joblib
 
 from vcm.cubedsphere.coarsen import (
     _block_mode,
@@ -27,7 +28,7 @@ from vcm.cubedsphere.constants import (
     COORD_Y_OUTER,
 )
 from vcm.cubedsphere.io import all_filenames
-from vcm.cubedsphere import create_fv3_grid
+from vcm.cubedsphere import create_fv3_grid, to_cross
 from vcm.xarray_utils import assert_identical_including_dtype
 import vcm.testing
 
@@ -817,3 +818,26 @@ def test_xgcm_grid_interp(grid_dataset):
 
     grid = create_fv3_grid(grid_dataset)
     grid.interp(grid_dataset.a, "x")
+
+
+@pytest.mark.parametrize("x_dim", ["grid_xt", "x"])
+@pytest.mark.parametrize("y_dim", ["grid_yt", "y"])
+@pytest.mark.parametrize("tile_dim", ["tile", "randomname"])
+@pytest.mark.parametrize("transpose", [True, False])
+def test_to_cross(transpose, tile_dim, x_dim, y_dim):
+    extra_dim = "extra"
+    arr = xr.DataArray(
+        np.arange(2 * 2 * 6).reshape((1, 6, 2, 2)),
+        dims=(extra_dim, tile_dim, y_dim, x_dim),
+    )
+
+    if transpose:
+        arr = arr.transpose(x_dim, tile_dim, extra_dim, y_dim)
+
+    one_tile = to_cross(arr, tile=tile_dim, x=x_dim, y=y_dim)
+    one_tile = one_tile.transpose(..., y_dim, x_dim)
+    assert one_tile.dims == (extra_dim, y_dim, x_dim)
+
+    # manually hardcode the hash since it is shared across all parameterize
+    # statements
+    assert joblib.hash(one_tile.values) == "77b919b5968584e9de056663979cb60e"

--- a/external/vcm/vcm/cubedsphere/__init__.py
+++ b/external/vcm/vcm/cubedsphere/__init__.py
@@ -15,5 +15,6 @@ from .rotate import center_and_rotate_xy_winds, rotate_xy_winds
 from .xgcm import create_fv3_grid
 from .coarsen_restarts import coarsen_restarts_on_pressure, coarsen_restarts_on_sigma
 from .regridz import regrid_vertical
+from .cross import to_cross
 
 __all__ = [item for item in dir() if not item.startswith("_")]

--- a/external/vcm/vcm/cubedsphere/cross.py
+++ b/external/vcm/vcm/cubedsphere/cross.py
@@ -1,0 +1,97 @@
+import xarray as xr
+import numpy as np
+
+from typing import Hashable
+
+from dataclasses import dataclass
+from functools import singledispatch
+
+SW = 3
+NW = 0
+NE = 1
+SE = 2
+
+__all__ = ["to_cross"]
+
+
+@dataclass
+class Tile:
+    x: int
+    y: int
+    origin: int
+
+
+TOPOLOGY = {
+    0: Tile(0, 1, SW),
+    1: Tile(1, 1, SW),
+    2: Tile(1, 2, SW),
+    3: Tile(2, 1, NW),
+    4: Tile(3, 1, NW),
+    5: Tile(1, 0, SE),
+}
+
+
+@singledispatch
+def rotate(data, origin, dest_origin):
+    return np.rot90(data, origin - dest_origin, axes=(-2, -1))
+
+
+@rotate.register(xr.Variable)
+def _rotate_variable(data, src, dest, dims=["grid_yt", "grid_xt"]):
+    return xr.apply_ufunc(
+        lambda x: rotate(x, src, dest),
+        data,
+        input_core_dims=[dims],
+        output_core_dims=[dims],
+        dask="allowed",
+    )
+
+
+@rotate.register(xr.DataArray)
+def _rotate_data_array(data, src, dest, dims=None):
+    variable = rotate(data.variable, src, dest, dims)
+    coords = {}
+    for key in data.coords:
+        if set(data[key].dims) >= set(dims):
+            coords[key] = rotate(data[key].variable, src, dest, dims)
+    return xr.DataArray(variable, coords=coords)
+
+
+def to_cross(
+    data: xr.DataArray,
+    tile: Hashable = "tile",
+    x: Hashable = "grid_xt",
+    y: Hashable = "grid_yt",
+) -> xr.DataArray:
+    """Combine tiles into a single 2D field resembling a "cross"
+
+    Useful for quickly plotting maps or applying other 2D image processing
+    techniques.
+    
+    See Also:
+
+        Weyn J, Durran D, and Caruana, 2019
+        https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2019MS001705
+
+    """
+    tiles = []
+    dims = [x, y]
+
+    data = data.drop_vars(dims + [tile], errors="ignore").transpose(..., tile, y, x)
+    null = xr.full_like(data.isel({tile: 0}), np.nan)
+    for j in range(3):
+        row = []
+        for i in range(4):
+            for tile_num, spec in TOPOLOGY.items():
+                if spec.y == j and spec.x == i:
+                    arr = rotate(
+                        data.isel({tile: tile_num}), spec.origin, SW, dims=dims
+                    )
+                    row.append(arr)
+                    break
+            else:
+                arr = null
+                row.append(arr)
+
+        tiles.append(row)
+    return xr.combine_nested(tiles, concat_dim=dims)

--- a/external/vcm/vcm/cubedsphere/cross.py
+++ b/external/vcm/vcm/cubedsphere/cross.py
@@ -75,7 +75,7 @@ def to_cross(
 
     """
     tiles = []
-    dims = [x, y]
+    dims = [y, x]
 
     data = data.drop_vars(dims + [tile], errors="ignore").transpose(..., tile, y, x)
     null = xr.full_like(data.isel({tile: 0}), np.nan)


### PR DESCRIPTION
This code was previously in my explore repo, and is pretty handy
for quickly visualizing cubed sphere data.

I used regression testing/hashing since it is hard to verify this works
without the grid data. You'll have to just trust me that this does
correctly unrotate the fields or try it out yourself.

Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

Added public API:
- `vcm.cubedsphere.to_cross`

- [x] Tests added


