### PR TITLE
prog_run: make run-native work for relative local paths

### DIFF
--- a/workflows/prognostic_c48_run/runfv3
+++ b/workflows/prognostic_c48_run/runfv3
@@ -138,11 +138,11 @@ function runSegment {
     write_run_directory "$fv3config" "$rundir"
     mkdir -p "$rundir"
     cp "$runfile" "$rundir/runfile.py"
+    NUM_PROC=$(yq '.namelist.fv_core_nml.layout | .[0] *.[1] * 6' "$fv3config")
     (
         cd "$rundir"
         find . > preexisting_files.txt
-        NUM_PROC=$(yq '.namelist.fv_core_nml.layout | .[0] *.[1] * 6' "$fv3config")
-        mpirun -n "$NUM_PROC" python3 -m mpi4py "$runfile" |& tee -a "$rundir/logs.txt"
+        mpirun -n "$NUM_PROC" python3 -m mpi4py "runfile.py" |& tee -a "logs.txt"
     )
 }
 


### PR DESCRIPTION
Currently, `runfv3 run-native` fails if the provided paths to the `fv3config` and `runfile` files are relative instead of absolute. 

In a roundabout way, this causes the issued raised in #1098: if the user supplied a local path that happened to be exactly `fv3config.yml`, then `run-native` would end up using the config yaml that gets written to the run directory by `write_run_directory`, which includes the `diag_table` as bytes, which causes `yq` to choke. A separate fv3config issue is that the `fv3config.yml` that gets written to the run directory is different than the input one. See https://github.com/VulcanClimateModeling/fv3config/issues/130.

Significant internal changes:
- allow `runSegment` (and therefore `run-native`) to work if the provided `fv3config` and `runfile` arguments are relative paths instead of absolute paths

- [ ] Tests added

Resolves #1098

