### PR TITLE
Prognostic run: use xr.Dataset.interp for the prescriber

### DIFF
--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -262,4 +262,4 @@ def _sst_from_reference(
         land_sea_mask.values.round().astype("int") == 0,
         reference_surface_temperature,
         surface_temperature,
-    ).assign_attrs(units=reference_surface_temperature.units)
+    ).assign_attrs(units=surface_temperature.units)

--- a/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
+++ b/workflows/prognostic_c48_run/runtime/steppers/prescriber.py
@@ -151,7 +151,7 @@ def _get_prescribed_ds(
     ds = _open_ds(dataset_key, consolidated)
     ds = get_variables(ds, variables)
     if timesteps is not None:
-        ds = ds.sel(time=timesteps)
+        ds = ds.interp(time=timesteps)
     time_coord = ds.coords["time"]
     return ds.drop_vars(names="time").load(), time_coord
 


### PR DESCRIPTION
This uses xarray's interpolation to interpolate for timesteps that don't have reference data when prescribing state updates in the nudged runs.