### PR TITLE
Enforce experiment workflows output pattern

### DIFF
--- a/docker/fv3net/Dockerfile
+++ b/docker/fv3net/Dockerfile
@@ -1,7 +1,7 @@
 FROM jupyter/base-notebook as build
 
 # Manually increment this string to invalidate the cache
-ENV MANUAL_CACHE_STRING 1
+ENV MANUAL_CACHE_STRING 2
 
 # Install dependencies (slow)
 USER root

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -374,8 +374,6 @@ spec:
             value: "{{workflow.parameters.tag}}"
           - name: step
             value: "nudge_to_fine_run"
-#           - name: output
-#             value: "{{workflow.parameters.root}}/nudge_to_fine_run"
           - name: config
             value: "{{workflow.parameters.nudge-to-fine-config}}"
           - name: segment-count
@@ -397,8 +395,6 @@ spec:
             value: "{{workflow.parameters.project}}"
           - name: tag
             value: "{{workflow.parameters.tag}}"
-#           - name: root
-#             value: "{{workflow.parameters.root}}"
           - name: train-test-data
             value: "{{tasks.resolve-output-url.outputs.result}}/nudge_to_fine_run"
           - name: training-configs

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -342,6 +342,18 @@ spec:
   - name: main
     dag:
       tasks:
+      - name: resolve-output-url
+        templateRef:
+          name: resolve-output-url
+          template: resolve-output-url
+        arguments:
+          parameters:
+            - name: bucket
+              value: "{{workflow.parameters.bucket}}"
+            - name: project
+              value: "{{workflow.parameters.project}}"
+            - name: tag
+              value: "{{workflow.parameters.tag}}"
       - name: nudge-to-fine-run
         templateRef:
           name: prognostic-run
@@ -354,8 +366,16 @@ spec:
             value: "{{workflow.parameters.initial-condition}}"
           - name: flags
             value: "--output-frequency {{workflow.parameters.nudge-to-fine-output-frequency}}"
-          - name: output
-            value: "{{workflow.parameters.root}}/nudge_to_fine_run"
+          - name: bucket
+            value: "{{workflow.parameters.bucket}}"
+          - name: project
+            value: "{{workflow.parameters.project}}"
+          - name: tag
+            value: "{{workflow.parameters.tag}}"
+          - name: step
+            value: "nudge_to_fine_run"
+#           - name: output
+#             value: "{{workflow.parameters.root}}/nudge_to_fine_run"
           - name: config
             value: "{{workflow.parameters.nudge-to-fine-config}}"
           - name: segment-count
@@ -371,10 +391,16 @@ spec:
           template: train-diags-prog
         arguments:
           parameters:
-          - name: root
-            value: "{{workflow.parameters.root}}"
+          - name: bucket
+            value: "{{workflow.parameters.bucket}}"
+          - name: project
+            value: "{{workflow.parameters.project}}"
+          - name: tag
+            value: "{{workflow.parameters.tag}}"
+#           - name: root
+#             value: "{{workflow.parameters.root}}"
           - name: train-test-data
-            value: "{{workflow.parameters.root}}/nudge_to_fine_run"
+            value: "{{tasks.resolve-output-url.outputs.result}}/nudge_to_fine_run"
           - name: training-configs
             value: "{{workflow.parameters.training-configs}}"
           - name: train-times
@@ -388,7 +414,7 @@ spec:
           - name: test-times
             value: "{{workflow.parameters.test-times}}"
           - name: public-report-output
-            value: "{{workflow.parameters.root}}/offline-report"
+            value: "{{tasks.resolve-output-url.outputs.result}}/offline-report"
           - name: cpu-prog
             value: "24"
           - name: memory-prog

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -381,7 +381,7 @@ spec:
           - name: memory
             value: 6Gi
       - name: train-offline-diags-prognostic
-        dependencies: [nudge-to-fine-run]
+        dependencies: [nudge-to-fine-run, resolve-output-url]
         templateRef:
           name: train-diags-prog
           template: train-diags-prog

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -376,6 +376,8 @@ spec:
             value: "{{workflow.parameters.nudge-to-fine-config}}"
           - name: segment-count
             value: "{{workflow.parameters.nudge-to-fine-segment-count}}"
+          - name: image-tags
+            value: "{{workflow.parameters.image-tags}}"
           - name: cpu
             value: 6000m
           - name: memory
@@ -409,6 +411,8 @@ spec:
             value: "{{workflow.parameters.test-times}}"
           - name: public-report-output
             value: "{{tasks.resolve-output-url.outputs.result}}/offline-report"
+          - name: image-tags
+            value: "{{workflow.parameters.image-tags}}"
           - name: cpu-prog
             value: "24"
           - name: memory-prog

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -376,8 +376,6 @@ spec:
             value: "{{workflow.parameters.nudge-to-fine-config}}"
           - name: segment-count
             value: "{{workflow.parameters.nudge-to-fine-segment-count}}"
-          - name: image-tags
-            value: "{{workflow.parameters.image-tags}}"
           - name: cpu
             value: 6000m
           - name: memory
@@ -411,8 +409,6 @@ spec:
             value: "{{workflow.parameters.test-times}}"
           - name: public-report-output
             value: "{{tasks.resolve-output-url.outputs.result}}/offline-report"
-          - name: image-tags
-            value: "{{workflow.parameters.image-tags}}"
           - name: cpu-prog
             value: "24"
           - name: memory-prog

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -353,7 +353,7 @@ spec:
             - name: project
               value: "{{workflow.parameters.project}}"
             - name: tag
-              value: "{{workflow.parameters.tag}}"
+              value: "{{workflow.parameters.tag}}-nudge-to-fine-run"
       - name: nudge-to-fine-run
         templateRef:
           name: prognostic-run
@@ -371,9 +371,7 @@ spec:
           - name: project
             value: "{{workflow.parameters.project}}"
           - name: tag
-            value: "{{workflow.parameters.tag}}"
-          - name: step
-            value: "nudge_to_fine_run"
+            value: "{{workflow.parameters.tag}}-nudge-to-fine-run"
           - name: config
             value: "{{workflow.parameters.nudge-to-fine-config}}"
           - name: segment-count
@@ -394,9 +392,9 @@ spec:
           - name: project
             value: "{{workflow.parameters.project}}"
           - name: tag
-            value: "{{workflow.parameters.tag}}"
+            value: "{{workflow.parameters.tag}}-train-diags-prog"
           - name: train-test-data
-            value: "{{tasks.resolve-output-url.outputs.result}}/nudge_to_fine_run"
+            value: "{{tasks.resolve-output-url.outputs.result}}/fv3gfs_run"
           - name: training-configs
             value: "{{workflow.parameters.training-configs}}"
           - name: train-times

--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -82,7 +82,7 @@ project="test-end-to-end-integration"
 cd tests/end_to_end_integration
 deployWorkflows "$registry" "$commit"
 argo submit argo.yaml -p bucket="${bucket}" -p project="${project}" \
-    -p tag="${commit}-${random}" --name "$name"
+    -p tag="${commit}-${random}" -p image-tags="{commit: ${commit}}" --name "$name"
 
 trap "argo logs \"$name\" | tail -n 100" EXIT
 

--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -57,7 +57,7 @@ function waitForComplete {
 function deployWorkflows {
 
     registry="$1"
-    tag="$2"
+    commit="$2"
 
     cat << EOF > kustomization.yaml
 resources:
@@ -65,27 +65,24 @@ resources:
 EOF
 
     kustomize edit set image \
-        us.gcr.io/vcm-ml/prognostic_run="$registry/prognostic_run:$tag" \
-        us.gcr.io/vcm-ml/fv3net="$registry/fv3net:$tag" \
-        us.gcr.io/vcm-ml/post_process_run="$registry/post_process_run:$tag"
+        us.gcr.io/vcm-ml/prognostic_run="$registry/prognostic_run:$commit" \
+        us.gcr.io/vcm-ml/fv3net="$registry/fv3net:$commit" \
+        us.gcr.io/vcm-ml/post_process_run="$registry/post_process_run:$commit"
 
     kustomize build . | kubectl apply -f -
 }
 
 registry="$1"
-tag="$2"
-fv3net="$PWD"
-# random="$(openssl rand --hex 6)"
-# name="integration-test-$random"
-name="integration-test-${tag}"
+commit="$2"
+random="$(openssl rand --hex 2)"
+name="integration-test-${commit}-${random}"
 bucket="vcm-ml-scratch"
 project="test-end-to-end-integration"
-# GCS_OUTPUT_URL="gs://vcm-ml-scratch/test-end-to-end-integration/$name"
 
 cd tests/end_to_end_integration
-deployWorkflows "$registry" "$tag"
+deployWorkflows "$registry" "$commit"
 argo submit argo.yaml -p bucket="${bucket}" -p project="${project}" \
-    -p tag="${tag}" --name "$name"
+    -p tag="${commit}-${random}" --name "$name"
 
 trap "argo logs \"$name\" | tail -n 100" EXIT
 

--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -75,13 +75,17 @@ EOF
 registry="$1"
 tag="$2"
 fv3net="$PWD"
-random="$(openssl rand --hex 6)"
-name="integration-test-$random"
-GCS_OUTPUT_URL="gs://vcm-ml-scratch/test-end-to-end-integration/$name"
+# random="$(openssl rand --hex 6)"
+# name="integration-test-$random"
+name="integration-test-${tag}"
+bucket="vcm-ml-scratch"
+project="test-end-to-end-integration"
+# GCS_OUTPUT_URL="gs://vcm-ml-scratch/test-end-to-end-integration/$name"
 
 cd tests/end_to_end_integration
 deployWorkflows "$registry" "$tag"
-argo submit argo.yaml -p root="$GCS_OUTPUT_URL" --name "$name"
+argo submit argo.yaml -p bucket="${bucket}" -p project="${project}" \
+    -p tag="${tag}" --name "$name"
 
 trap "argo logs \"$name\" | tail -n 100" EXIT
 

--- a/tests/end_to_end_integration/run_test.sh
+++ b/tests/end_to_end_integration/run_test.sh
@@ -82,7 +82,7 @@ project="test-end-to-end-integration"
 cd tests/end_to_end_integration
 deployWorkflows "$registry" "$commit"
 argo submit argo.yaml -p bucket="${bucket}" -p project="${project}" \
-    -p tag="${commit}-${random}" -p image-tags="{commit: ${commit}}" --name "$name"
+    -p tag="${commit}-${random}" --name "$name"
 
 trap "argo logs \"$name\" | tail -n 100" EXIT
 

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -64,20 +64,19 @@ sequential segments.
 | `initial-condition`  | Timestamp string for time at which to begin the prognostic run                |
 | `config`             | String representation of base config YAML file; supplied to prepare_config.py |
 | `reference-restarts` | Location of restart data for initializing the prognostic run                  |
-| `tag`                | Experiment tag                                                                |
-| `flags`              | (optional) extra command line flags for prepare_config.py                     |
+| `tag`                | Tag which describes the run and is used in its storage location               | 
+| `flags`              | (optional) Extra command line flags for prepare_config.py                     |
 | `bucket`             | (optional) Bucket to save run output data; default 'vcm-ml-experiments'       |
 | `project`            | (optional) Project directory to save run output data; default 'default'       |
-| `step`               | (optional) Run step name within experiment; default 'prognostic_run'          |
 | `segment-count`      | (optional) Number of prognostic run segments; default "1"                     |
 | `cpu`                | (optional) Number of cpus to request; default "6"                             |
 | `memory`             | (optional) Amount of memory to request; default 6Gi                           |
-| `config-sha1`        | (optional) Config commit of workflow run to write to output; not written by default |
+| `image-tags`         | (optional) Commit tags written to image-tags.yaml; not written by default     |
 
 #### Command line interfaces used by workflow
 This workflow first resolves the output location for the run according to:
 ```
-output="gs://{bucket}/{project}/$(date +%F)/{tag}/{step}"
+output="gs://{bucket}/{project}/$(date +%F)/{tag}/fv3gfs_run"
 ```
 
 And then calls:
@@ -261,7 +260,7 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 
 | Parameter               | Description                                                           |
 |-------------------------|-----------------------------------------------------------------------|
-| `tag`                   | Experiment tag                                                        |
+| `tag`                   | Tag which describes the experiment and is used in its storage location| 
 | `train-test-data`       | `input` for `training` workflow                                       |
 | `training-configs`      | List of dicts of type `{name: config}`, where `config` is the config used for `training` workflow |
 | `train-times`           | `times` for `training` workflow                                       |
@@ -280,7 +279,7 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `memory-offline-diags`  | (optional) `memory` for `offline-diags` workflow; default 6Gi         |
 | `training-flags`        | (optional) `flags` for `training` workflow                            |
 | `online-diags-flags`    | (optional) `flags` for `prognostic-run-diags` workflow                |
-| `config-sha1`           | (optional) Config commit of workflow run to write to output; not written by default |
+| `image-tags`            | (optional) Commit tags written to image-tags.yaml; not written by default |
 
 Output for the various steps will be written to `gs://{bucket}/{project}/$(date +%F)/{tag}`.
 

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -72,6 +72,7 @@ sequential segments.
 | `segment-count`      | (optional) Number of prognostic run segments; default "1"                     |
 | `cpu`                | (optional) Number of cpus to request; default "6"                             |
 | `memory`             | (optional) Amount of memory to request; default 6Gi                           |
+| `config-sha1`        | (optional) Config commit of workflow run to write to output; not written by default |
 
 #### Command line interfaces used by workflow
 This workflow first resolves the output location for the run according to:
@@ -279,6 +280,7 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `memory-offline-diags`  | (optional) `memory` for `offline-diags` workflow; default 6Gi         |
 | `training-flags`        | (optional) `flags` for `training` workflow                            |
 | `online-diags-flags`    | (optional) `flags` for `prognostic-run-diags` workflow                |
+| `config-sha1`           | (optional) Config commit of workflow run to write to output; not written by default |
 
 Output for the various steps will be written to `gs://{bucket}/{project}/$(date +%F)/{tag}`.
 

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -78,6 +78,8 @@ This workflow first resolves the output location for the run according to:
 ```
 output="gs://{bucket}/{project}/$(date +%F)/{tag}/fv3gfs_run"
 ```
+Any slashes in `bucket`, `project` and `tag` will be converted to a dash (`-`) to
+preserve the depth of this directory structure.
 
 And then calls:
 ```
@@ -282,6 +284,8 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `image-tags`            | (optional) Commit tags written to image-tags.yaml; not written by default |
 
 Output for the various steps will be written to `gs://{bucket}/{project}/$(date +%F)/{tag}`.
+Any slashes in `bucket`, `project` and `tag` will be converted to a dash (`-`) to
+preserve the depth of this directory structure.
 
 ### Cubed-sphere to lat-lon interpolation workflow
 

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -28,7 +28,6 @@ This job can be monitored by running
 
 These workflows currently refer to following images without using any tags:
 1. us.gcr.io/vcm-ml/fv3net
-1. us.gcr.io/vcm-ml/fv3fit
 1. us.gcr.io/vcm-ml/prognostic_run
 1. us.gcr.io/vcm-ml/post_process_run
 
@@ -42,8 +41,6 @@ resources:
 - <path/to/fv3net/workflows/argo>
 kind: Kustomization
 images:
-- name: us.gcr.io/vcm-ml/fv3fit
-  newTag: 6e121e84e3a874c001b3b8d1b437813c9859e078
 - name: us.gcr.io/vcm-ml/fv3net
   newTag: 6e121e84e3a874c001b3b8d1b437813c9859e078
 - name: us.gcr.io/vcm-ml/post_process_run
@@ -67,14 +64,22 @@ sequential segments.
 | `initial-condition`  | Timestamp string for time at which to begin the prognostic run                |
 | `config`             | String representation of base config YAML file; supplied to prepare_config.py |
 | `reference-restarts` | Location of restart data for initializing the prognostic run                  |
-| `output`             | Location to save prognostic run output                                        |
+| `tag`                | Experiment tag                                                                |
 | `flags`              | (optional) extra command line flags for prepare_config.py                     |
+| `bucket`             | (optional) Bucket to save run output data; default 'vcm-ml-experiments'       |
+| `project`            | (optional) Project directory to save run output data; default 'default'       |
+| `step`               | (optional) Run step name within experiment; default 'prognostic_run'          |
 | `segment-count`      | (optional) Number of prognostic run segments; default "1"                     |
 | `cpu`                | (optional) Number of cpus to request; default "6"                             |
 | `memory`             | (optional) Amount of memory to request; default 6Gi                           |
 
 #### Command line interfaces used by workflow
-This workflow calls:
+This workflow first resolves the output location for the run according to:
+```
+output="gs://{bucket}/{project}/$(date +%F)/{tag}/{step}"
+```
+
+And then calls:
 ```
 python3 /fv3net/workflows/prognostic_c48_run/prepare_config.py \
         {{inputs.parameters.flags}} \
@@ -85,11 +90,11 @@ python3 /fv3net/workflows/prognostic_c48_run/prepare_config.py \
 ```
 And then
 ```
-runfv3 create {{inputs.parameters.output}} /tmp/fv3config.yaml /fv3net/workflows/prognostic_c48_run/sklearn_runfile.py
+runfv3 create {output} /tmp/fv3config.yaml /fv3net/workflows/prognostic_c48_run/sklearn_runfile.py
 ```
 Followed by `segment-count` iterations of
 ```
-runfv3 append {{inputs.parameters.output}}
+runfv3 append {output}
 ```
 
 #### Volumes used by run-fv3gfs template
@@ -197,7 +202,7 @@ This workflow trains machine learning models.
 | `input`                | Location of dataset for training data                |
 | `config`               | Model training config yaml                           |
 | `times`                | JSON-encoded list of timestamps to use for test data |
-| `offline-diags-output` | Where to save offline diagnsostics                   |
+| `offline-diags-output` | Where to save offline diagnostics                    |
 | `report-output`        | Where to save report                                 |
 | `memory`               | (optional) memory for workflow. Defaults to 6Gi.     |
 
@@ -255,16 +260,17 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 
 | Parameter               | Description                                                           |
 |-------------------------|-----------------------------------------------------------------------|
-| `root`                  | URL for the outputs from this workflow                                |
+| `tag`                   | Experiment tag                                                        |
 | `train-test-data`       | `input` for `training` workflow                                       |
-| `training-configs`      | List of dicts with keys `name`, `config`, where `config` is the 
-                            config used for `training` workflow                                   |
+| `training-configs`      | List of dicts of type `{name: config}`, where `config` is the config used for `training` workflow |
 | `train-times`           | `times` for `training` workflow                                       |
 | `test-times`            | `times` for `offline-diags` workflow                                  |
 | `public-report-output`  | `report-output` for `offline-diags` workflow                          |
 | `initial-condition`     | `initial-condition` for `prognostic-run` workflow                     |
 | `prognostic-run-config` | `config` for `prognostic-run` workflow                                |
 | `reference-restarts`    | `reference-restarts` for `prognostic-run` workflow                    |
+| `bucket`                | (optional) Bucket to save output data; default 'vcm-ml-experiments'   |
+| `project`               | (optional) Project directory to save output data; default 'default'   |
 | `flags`                 | (optional) `flags` for `prognostic-run` workflow                      |
 | `segment-count`         | (optional) `segment-count` for `prognostic-run` workflow; default "1" |
 | `cpu-prog`              | (optional) `cpu` for `prognostic-run` workflow; default "6"           |
@@ -273,6 +279,8 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `memory-offline-diags`  | (optional) `memory` for `offline-diags` workflow; default 6Gi         |
 | `training-flags`        | (optional) `flags` for `training` workflow                            |
 | `online-diags-flags`    | (optional) `flags` for `prognostic-run-diags` workflow                |
+
+Output for the various steps will be written to `gs://{bucket}/{project}/$(date +%F)/{tag}`.
 
 ### Cubed-sphere to lat-lon interpolation workflow
 

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -71,15 +71,14 @@ sequential segments.
 | `segment-count`      | (optional) Number of prognostic run segments; default "1"                     |
 | `cpu`                | (optional) Number of cpus to request; default "6"                             |
 | `memory`             | (optional) Amount of memory to request; default 6Gi                           |
-| `image-tags`         | (optional) Commit tags written to image-tags.yaml; not written by default     |
 
 #### Command line interfaces used by workflow
 This workflow first resolves the output location for the run according to:
 ```
 output="gs://{bucket}/{project}/$(date +%F)/{tag}/fv3gfs_run"
 ```
-Any slashes in `bucket`, `project` and `tag` will be converted to a dash (`-`) to
-preserve the depth of this directory structure.
+Slashes (`/`) are not permitted in `bucket`, `project` and `tag` to preserve the depth 
+of this directory structure.
 
 And then calls:
 ```
@@ -281,11 +280,10 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `memory-offline-diags`  | (optional) `memory` for `offline-diags` workflow; default 6Gi         |
 | `training-flags`        | (optional) `flags` for `training` workflow                            |
 | `online-diags-flags`    | (optional) `flags` for `prognostic-run-diags` workflow                |
-| `image-tags`            | (optional) Commit tags written to image-tags.yaml; not written by default |
 
 Output for the various steps will be written to `gs://{bucket}/{project}/$(date +%F)/{tag}`.
-Any slashes in `bucket`, `project` and `tag` will be converted to a dash (`-`) to
-preserve the depth of this directory structure.
+Slashes (`/`) are not permitted in `bucket`, `project` and `tag` to preserve the depth 
+of this directory structure.
 
 ### Cubed-sphere to lat-lon interpolation workflow
 

--- a/workflows/argo/kustomization.yaml
+++ b/workflows/argo/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - offline-diags.yaml
 - train-diags-prog.yaml
 - cubed-to-latlon.yaml
+- resolve-output-url.yaml
 configurations:
 - image-transformerconfig.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -26,7 +26,6 @@ spec:
           - {name: flags, value: ""}
           - {name: bucket, value: "vcm-ml-experiments"}
           - {name: project, value: "default"}
-          - {name: step, value: "prognostic_run"}
           - {name: segment-count, value: "1"}
           - {name: cpu, value: "6"}
           - {name: memory, value: 6Gi}
@@ -58,7 +57,7 @@ spec:
               - {name: fv3config, from: "{{steps.prepare-config.outputs.artifacts.fv3config}}"}
               - {name: runfile, from: "{{steps.prepare-config.outputs.artifacts.runfile}}"}
             parameters:
-              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/{{inputs.parameters.step}}"}
+              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/fv3gfs_run"}
               - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -67,7 +67,7 @@ spec:
             template: write-config-sha1
           arguments:
             parameters:
-              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/{{inputs.parameters.step}}"}
+              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/fv3gfs_run"}
               - {name: config-sha1, value: "{{inputs.parameters.config-sha1}}"}
     - name: prepare-config
       inputs:

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -40,7 +40,6 @@ spec:
               - {name: bucket, value: "{{inputs.parameters.bucket}}"}
               - {name: project, value: "{{inputs.parameters.project}}"}
               - {name: tag, value: "{{inputs.parameters.tag}}"}
-              - {name: step, value: "{{inputs.parameters.step}}"}
       - - name: prepare-config
           template: prepare-config
           arguments:
@@ -58,7 +57,7 @@ spec:
               - {name: fv3config, from: "{{steps.prepare-config.outputs.artifacts.fv3config}}"}
               - {name: runfile, from: "{{steps.prepare-config.outputs.artifacts.runfile}}"}
             parameters:
-              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}"}
+              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/{{inputs.parameters.step}}"}
               - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -29,7 +29,6 @@ spec:
           - {name: segment-count, value: "1"}
           - {name: cpu, value: "6"}
           - {name: memory, value: 6Gi}
-          - {name: image-tags, value: ""}
       steps:
       - - name: resolve-output-url
           templateRef:
@@ -61,14 +60,6 @@ spec:
               - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}
-      - - name: write-image-tags
-          templateRef:
-            name: resolve-output-url
-            template: write-image-tags
-          arguments:
-            parameters:
-              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/fv3gfs_run"}
-              - {name: image-tags, value: "{{inputs.parameters.image-tags}}"}
     - name: prepare-config
       inputs:
         parameters:

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -30,6 +30,7 @@ spec:
           - {name: segment-count, value: "1"}
           - {name: cpu, value: "6"}
           - {name: memory, value: 6Gi}
+          - {name: config-sha1, value: ""}
       steps:
       - - name: resolve-output-url
           templateRef:
@@ -61,6 +62,14 @@ spec:
               - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}
+      - - name: write-config-sha1
+          templateRef:
+            name: resolve-output-url
+            template: write-config-sha1
+          arguments:
+            parameters:
+              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/{{inputs.parameters.step}}"}
+              - {name: config-sha1, value: "{{inputs.parameters.config-sha1}}"}
     - name: prepare-config
       inputs:
         parameters:

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -81,7 +81,6 @@ spec:
           - {name: fv3config, path: /tmp/fv3config.yaml}
           - name: runfile
             path: /tmp/runfile.py
-          - {name: output-url, path: /tmp/}
       container:
         image: us.gcr.io/vcm-ml/prognostic_run
         command: ["bash", "-c", "-x", "-e"]

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -29,7 +29,7 @@ spec:
           - {name: segment-count, value: "1"}
           - {name: cpu, value: "6"}
           - {name: memory, value: 6Gi}
-          - {name: config-sha1, value: ""}
+          - {name: image-tags, value: ""}
       steps:
       - - name: resolve-output-url
           templateRef:
@@ -61,14 +61,14 @@ spec:
               - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}
-      - - name: write-config-sha1
+      - - name: write-image-tags
           templateRef:
             name: resolve-output-url
-            template: write-config-sha1
+            template: write-image-tags
           arguments:
             parameters:
               - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}/fv3gfs_run"}
-              - {name: config-sha1, value: "{{inputs.parameters.config-sha1}}"}
+              - {name: image-tags, value: "{{inputs.parameters.image-tags}}"}
     - name: prepare-config
       inputs:
         parameters:

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -22,12 +22,25 @@ spec:
           - {name: initial-condition}
           - {name: config}
           - {name: reference-restarts}
+          - {name: tag}
           - {name: flags, value: ""}
-          - {name: output}
+          - {name: bucket, value: "vcm-ml-experiments"}
+          - {name: project, value: "default"}
+          - {name: step, value: "prognostic_run"}
           - {name: segment-count, value: "1"}
           - {name: cpu, value: "6"}
           - {name: memory, value: 6Gi}
       steps:
+      - - name: resolve-output-url
+          templateRef:
+            name: resolve-output-url
+            template: resolve-output-url
+          arguments:
+            parameters:
+              - {name: bucket, value: "{{inputs.parameters.bucket}}"}
+              - {name: project, value: "{{inputs.parameters.project}}"}
+              - {name: tag, value: "{{inputs.parameters.tag}}"}
+              - {name: step, value: "{{inputs.parameters.step}}"}
       - - name: prepare-config
           template: prepare-config
           arguments:
@@ -45,7 +58,7 @@ spec:
               - {name: fv3config, from: "{{steps.prepare-config.outputs.artifacts.fv3config}}"}
               - {name: runfile, from: "{{steps.prepare-config.outputs.artifacts.runfile}}"}
             parameters:
-              - {name: output-url, value: "{{inputs.parameters.output}}"}
+              - {name: output-url, value: "{{steps.resolve-output-url.outputs.result}}"}
               - {name: segment-count, value: "{{inputs.parameters.segment-count}}"}
               - {name: cpu, value: "{{inputs.parameters.cpu}}"}
               - {name: memory, value: "{{inputs.parameters.memory}}"}
@@ -61,6 +74,7 @@ spec:
           - {name: fv3config, path: /tmp/fv3config.yaml}
           - name: runfile
             path: /tmp/runfile.py
+          - {name: output-url, path: /tmp/}
       container:
         image: us.gcr.io/vcm-ml/prognostic_run
         command: ["bash", "-c", "-x", "-e"]

--- a/workflows/argo/resolve-output-url.yaml
+++ b/workflows/argo/resolve-output-url.yaml
@@ -19,3 +19,19 @@ spec:
           DATE=$(date +'%F')
           echo "gs://{{inputs.parameters.bucket}}/{{inputs.parameters.project}}/\
           ${DATE}/{{inputs.parameters.tag}}"
+    - name: write-config-sha1
+      inputs:
+        parameters:
+          - name: output-url
+          - {name: config-sha1, value: ""}
+      script:
+        image: us.gcr.io/vcm-ml/prognostic_run
+        command: [bash]
+        source: |
+          set -e
+          if [[ -n "{{inputs.parameters.config-sha1}}" ]]; then
+            echo "{{inputs.parameters.config-sha1}}" >> config-sha1.txt
+            gsutil cp config-sha1.txt "{{inputs.parameters.output-url}}/config-sha1.txt"
+          fi
+          
+          

--- a/workflows/argo/resolve-output-url.yaml
+++ b/workflows/argo/resolve-output-url.yaml
@@ -24,19 +24,21 @@ spec:
           PROJECT=$(remove_slashes {{inputs.parameters.project}})
           TAG=$(remove_slashes {{inputs.parameters.tag}})
           echo "gs://${BUCKET}/${PROJECT}/${DATE}/${TAG}"
-    - name: write-config-sha1
+    - name: write-image-tags
       inputs:
         parameters:
           - name: output-url
-          - {name: config-sha1, value: ""}
+          - {name: image-tags, value: ""}
       script:
         image: us.gcr.io/vcm-ml/prognostic_run
         command: [bash]
         source: |
           set -e
-          if [[ -n "{{inputs.parameters.config-sha1}}" ]]; then
-            echo "{{inputs.parameters.config-sha1}}" >> config-sha1.txt
-            gsutil cp config-sha1.txt "{{inputs.parameters.output-url}}/config-sha1.txt"
+          cat << EOF > image-tags.yaml
+          {{inputs.parameters.image-tags}}
+          EOF
+          if [[ -n "{{inputs.parameters.image-tags}}" ]]; then
+            gsutil cp image-tags.yaml "{{inputs.parameters.output-url}}/image-tags.yaml"
           fi
           
           

--- a/workflows/argo/resolve-output-url.yaml
+++ b/workflows/argo/resolve-output-url.yaml
@@ -1,0 +1,22 @@
+# vim: set sts=2 ts=2 tw=2 sw=2 :
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: resolve-output-url
+spec:
+  templates:
+    - name: resolve-output-url
+      inputs:
+        parameters:
+          - name: bucket
+          - name: project
+          - name: tag
+          - name: step
+      script:
+        image: debian:9.4
+        command: [bash]
+        source: |
+          set -e
+          DATE=$(date +'%F')
+          echo "gs://{{inputs.parameters.bucket}}/{{inputs.parameters.project}}/\
+          ${DATE}/{{inputs.parameters.tag}}/{{inputs.parameters.step}}"

--- a/workflows/argo/resolve-output-url.yaml
+++ b/workflows/argo/resolve-output-url.yaml
@@ -16,29 +16,15 @@ spec:
         command: [bash]
         source: |
           set -e
-          remove_slashes () {
-              echo $(echo $1 | sed -e 's~/~-~')
+          fail_on_slash () {
+            if [[ "$1" == *"/"* ]]; then
+              echo "Slashes not permitted in bucket, project, and tag: $1"
+              exit 1
+            fi
           }
           DATE=$(date +'%F')
-          BUCKET=$(remove_slashes {{inputs.parameters.bucket}})
-          PROJECT=$(remove_slashes {{inputs.parameters.project}})
-          TAG=$(remove_slashes {{inputs.parameters.tag}})
-          echo "gs://${BUCKET}/${PROJECT}/${DATE}/${TAG}"
-    - name: write-image-tags
-      inputs:
-        parameters:
-          - name: output-url
-          - {name: image-tags, value: ""}
-      script:
-        image: us.gcr.io/vcm-ml/prognostic_run
-        command: [bash]
-        source: |
-          set -e
-          cat << EOF > image-tags.yaml
-          {{inputs.parameters.image-tags}}
-          EOF
-          if [[ -n "{{inputs.parameters.image-tags}}" ]]; then
-            gsutil cp image-tags.yaml "{{inputs.parameters.output-url}}/image-tags.yaml"
-          fi
-          
+          fail_on_slash {{inputs.parameters.bucket}}
+          fail_on_slash {{inputs.parameters.project}}
+          fail_on_slash {{inputs.parameters.tag}}
+          echo "gs://{{inputs.parameters.bucket}}/{{inputs.parameters.project}}/${DATE}/{{inputs.parameters.tag}}"
           

--- a/workflows/argo/resolve-output-url.yaml
+++ b/workflows/argo/resolve-output-url.yaml
@@ -11,7 +11,6 @@ spec:
           - name: bucket
           - name: project
           - name: tag
-          - name: step
       script:
         image: debian:9.4
         command: [bash]
@@ -19,4 +18,4 @@ spec:
           set -e
           DATE=$(date +'%F')
           echo "gs://{{inputs.parameters.bucket}}/{{inputs.parameters.project}}/\
-          ${DATE}/{{inputs.parameters.tag}}/{{inputs.parameters.step}}"
+          ${DATE}/{{inputs.parameters.tag}}"

--- a/workflows/argo/resolve-output-url.yaml
+++ b/workflows/argo/resolve-output-url.yaml
@@ -16,9 +16,14 @@ spec:
         command: [bash]
         source: |
           set -e
+          remove_slashes () {
+              echo $(echo $1 | sed -e 's~/~-~')
+          }
           DATE=$(date +'%F')
-          echo "gs://{{inputs.parameters.bucket}}/{{inputs.parameters.project}}/\
-          ${DATE}/{{inputs.parameters.tag}}"
+          BUCKET=$(remove_slashes {{inputs.parameters.bucket}})
+          PROJECT=$(remove_slashes {{inputs.parameters.project}})
+          TAG=$(remove_slashes {{inputs.parameters.tag}})
+          echo "gs://${BUCKET}/${PROJECT}/${DATE}/${TAG}"
     - name: write-config-sha1
       inputs:
         parameters:

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -39,7 +39,7 @@ spec:
       - {name: memory-offline-diags, value: 6Gi}
       - {name: training-flags, value: " "}
       - {name: online-diags-flags, value: " "}
-      - {name: config-sha1, value: ""}
+      - {name: image-tags, value: ""}
     dag:
       tasks:
       - name: resolve-output-url
@@ -54,15 +54,15 @@ spec:
               value: "{{inputs.parameters.project}}"
             - name: tag
               value: "{{inputs.parameters.tag}}"
-      - name: write-config-sha1
+      - name: write-image-tags
         dependencies: [resolve-output-url]
         templateRef:
           name: resolve-output-url
-          template: write-config-sha1
+          template: write-image-tags
         arguments:
           parameters:
             - {name: output-url, value: "{{tasks.resolve-output-url.outputs.result}}"}
-            - {name: config-sha1, value: "{{inputs.parameters.config-sha1}}"}
+            - {name: image-tags, value: "{{inputs.parameters.image-tags}}"}
       - name: train-model
         dependencies: [resolve-output-url]
         templateRef:

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -19,7 +19,7 @@ spec:
   - name: train-diags-prog
     inputs:
       parameters:
-      - name: root
+      - name: tag
       - name: train-test-data
       - name: training-configs  # used in withParam
       - name: train-times
@@ -30,6 +30,8 @@ spec:
         value: " "
       - name: test-times
       - name: public-report-output
+      - {name: bucket, value: "vcm-ml-experiments"}
+      - {name: project, value: "default"}
       - {name: segment-count, value: "1"}
       - {name: cpu-prog, value: "6"}
       - {name: memory-prog, value: 6Gi}
@@ -39,6 +41,18 @@ spec:
       - {name: online-diags-flags, value: " "}
     dag:
       tasks:
+      - name: resolve-output-url
+        templateRef:
+          name: resolve-output-url
+          template: resolve-output-url
+        arguments:
+          parameters:
+            - name: bucket
+              value: "{{inputs.parameters.bucket}}"
+            - name: project
+              value: "{{inputs.parameters.project}}"
+            - name: tag
+              value: "{{inputs.parameters.tag}}"
       - name: train-model
         templateRef:
           name: training
@@ -53,7 +67,7 @@ spec:
             - name: times
               value: "{{inputs.parameters.train-times}}"
             - name: output
-              value: "{{inputs.parameters.root}}/trained_models/{{item.name}}"
+              value: "{{steps.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
             - name: memory
               value: "{{inputs.parameters.memory-training}}"
             - name: flags
@@ -67,11 +81,11 @@ spec:
         arguments:
           parameters:
               - name: ml-model
-                value: "{{inputs.parameters.root}}/trained_models/{{item.name}}"
+                value: "{{steps.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
               - name: times
                 value: "{{inputs.parameters.test-times}}"
               - name: offline-diags-output
-                value: "{{inputs.parameters.root}}/offline_diags/{{item.name}}"
+                value: "{{steps.resolve-output-url.outputs.result}}/offline_diags/{{item.name}}"
               - name: report-output
                 value: "{{inputs.parameters.public-report-output}}/{{item.name}}"
               - name: memory
@@ -81,7 +95,7 @@ spec:
         arguments:
           parameters:
               - name: root
-                value: "{{inputs.parameters.root}}"
+                value: "{{steps.resolve-output-url.outputs.result}}"
               - name: training-configs
                 value: "{{inputs.parameters.training-configs}}"
               - name: flags
@@ -99,12 +113,16 @@ spec:
                 value: "{{inputs.parameters.prognostic-run-config}}"
               - name: reference-restarts
                 value: "{{inputs.parameters.reference-restarts}}"
-              - name: output
-                value: "{{inputs.parameters.root}}/prognostic_run"
+              - name: bucket
+                value: "{{inputs.parameters.bucket}}"
+              - name: project
+                value: "{{inputs.parameters.project}}"
+              - name: tag
+                value: "{{inputs.parameters.tag}}"
               - name: flags
                 value: "{{tasks.construct-full-flags.outputs.parameters.prognostic-flags}}"
               - name: models-dir
-                value: "{{inputs.parameters.root}}/trained_models"
+                value: "{{steps.resolve-output-url.outputs.result}}/trained_models"
               - name: segment-count
                 value: "{{inputs.parameters.segment-count}}"
               - name: cpu
@@ -119,9 +137,9 @@ spec:
         arguments:
           parameters:
               - name: run
-                value: "{{inputs.parameters.root}}/prognostic_run"
+                value: "{{steps.resolve-output-url.outputs.result}}/prognostic_run"
               - name: output
-                value: "{{inputs.parameters.root}}/prognostic_run_diags"
+                value: "{{steps.resolve-output-url.outputs.result}}/prognostic_run_diags"
               - name: flags
                 value: "{{inputs.parameters.online-diags-flags}}"
   - name: construct-full-flags

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -141,7 +141,7 @@ spec:
               - name: run
                 value: "{{tasks.resolve-output-url.outputs.result}}/fv3gfs_run"
               - name: output
-                value: "{{tasks.resolve-output-url.outputs.result}}/fv3gfs_run_diags"
+                value: "{{tasks.resolve-output-url.outputs.result}}/fv3gfs_run_diagnostics"
               - name: flags
                 value: "{{inputs.parameters.online-diags-flags}}"
   - name: construct-full-flags

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -149,9 +149,9 @@ spec:
         arguments:
           parameters:
               - name: run
-                value: "{{tasks.resolve-output-url.outputs.result}}/prognostic_run"
+                value: "{{tasks.resolve-output-url.outputs.result}}/fv3gfs_run"
               - name: output
-                value: "{{tasks.resolve-output-url.outputs.result}}/prognostic_run_diags"
+                value: "{{tasks.resolve-output-url.outputs.result}}/fv3gfs_run_diags"
               - name: flags
                 value: "{{inputs.parameters.online-diags-flags}}"
   - name: construct-full-flags

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -39,7 +39,6 @@ spec:
       - {name: memory-offline-diags, value: 6Gi}
       - {name: training-flags, value: " "}
       - {name: online-diags-flags, value: " "}
-      - {name: image-tags, value: ""}
     dag:
       tasks:
       - name: resolve-output-url
@@ -54,15 +53,6 @@ spec:
               value: "{{inputs.parameters.project}}"
             - name: tag
               value: "{{inputs.parameters.tag}}"
-      - name: write-image-tags
-        dependencies: [resolve-output-url]
-        templateRef:
-          name: resolve-output-url
-          template: write-image-tags
-        arguments:
-          parameters:
-            - {name: output-url, value: "{{tasks.resolve-output-url.outputs.result}}"}
-            - {name: image-tags, value: "{{inputs.parameters.image-tags}}"}
       - name: train-model
         dependencies: [resolve-output-url]
         templateRef:

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -54,6 +54,7 @@ spec:
             - name: tag
               value: "{{inputs.parameters.tag}}"
       - name: train-model
+        dependencies: [resolve-output-url]
         templateRef:
           name: training
           template: training
@@ -67,7 +68,7 @@ spec:
             - name: times
               value: "{{inputs.parameters.train-times}}"
             - name: output
-              value: "{{steps.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
+              value: "{{tasks.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
             - name: memory
               value: "{{inputs.parameters.memory-training}}"
             - name: flags
@@ -81,21 +82,22 @@ spec:
         arguments:
           parameters:
               - name: ml-model
-                value: "{{steps.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
+                value: "{{tasks.resolve-output-url.outputs.result}}/trained_models/{{item.name}}"
               - name: times
                 value: "{{inputs.parameters.test-times}}"
               - name: offline-diags-output
-                value: "{{steps.resolve-output-url.outputs.result}}/offline_diags/{{item.name}}"
+                value: "{{tasks.resolve-output-url.outputs.result}}/offline_diags/{{item.name}}"
               - name: report-output
                 value: "{{inputs.parameters.public-report-output}}/{{item.name}}"
               - name: memory
                 value: "{{inputs.parameters.memory-offline-diags}}"
       - name: construct-full-flags
+        dependencies: [resolve-output-url]
         template: construct-full-flags
         arguments:
           parameters:
               - name: root
-                value: "{{steps.resolve-output-url.outputs.result}}"
+                value: "{{tasks.resolve-output-url.outputs.result}}"
               - name: training-configs
                 value: "{{inputs.parameters.training-configs}}"
               - name: flags
@@ -122,7 +124,7 @@ spec:
               - name: flags
                 value: "{{tasks.construct-full-flags.outputs.parameters.prognostic-flags}}"
               - name: models-dir
-                value: "{{steps.resolve-output-url.outputs.result}}/trained_models"
+                value: "{{tasks.resolve-output-url.outputs.result}}/trained_models"
               - name: segment-count
                 value: "{{inputs.parameters.segment-count}}"
               - name: cpu
@@ -137,9 +139,9 @@ spec:
         arguments:
           parameters:
               - name: run
-                value: "{{steps.resolve-output-url.outputs.result}}/prognostic_run"
+                value: "{{tasks.resolve-output-url.outputs.result}}/prognostic_run"
               - name: output
-                value: "{{steps.resolve-output-url.outputs.result}}/prognostic_run_diags"
+                value: "{{tasks.resolve-output-url.outputs.result}}/prognostic_run_diags"
               - name: flags
                 value: "{{inputs.parameters.online-diags-flags}}"
   - name: construct-full-flags

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -39,6 +39,7 @@ spec:
       - {name: memory-offline-diags, value: 6Gi}
       - {name: training-flags, value: " "}
       - {name: online-diags-flags, value: " "}
+      - {name: config-sha1, value: ""}
     dag:
       tasks:
       - name: resolve-output-url
@@ -53,6 +54,15 @@ spec:
               value: "{{inputs.parameters.project}}"
             - name: tag
               value: "{{inputs.parameters.tag}}"
+      - name: write-config-sha1
+        dependencies: [resolve-output-url]
+        templateRef:
+          name: resolve-output-url
+          template: write-config-sha1
+        arguments:
+          parameters:
+            - {name: output-url, value: "{{tasks.resolve-output-url.outputs.result}}"}
+            - {name: config-sha1, value: "{{inputs.parameters.config-sha1}}"}
       - name: train-model
         dependencies: [resolve-output-url]
         templateRef:


### PR DESCRIPTION
Enforces an output location pattern for experiment argo workflows. The pattern is `gs://{bucket}/{project}/$(date +%F)/{tag}/{step}`, where `bucket` defaults to 'vcm-ml-experiments', `project` defaults to 'default', `tag` is supplied by the user, and `step` is defined by the workflow.

Refactored public API:
- For the `prognostic-run` and `train-diags-prog` workflows, users no longer specify the output path directly, instead specifying the experiment tag, and the bucket and project if need be.
- All workflows using the `prognostic-run` workflow template now write out to a step directory called `fv3gfs_run`.
- The e2e test now writes to a directory in `vcm-ml-scratch` whose path contains the date and commit plus a random string; the nudge-to-fine run and train-diags-prog portions are written under different tags in this directory.

