### PR TITLE
Infer tendency and storage variables from config.diagnostics

### DIFF
--- a/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression.out
+++ b/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_ml_config_regression.out
@@ -1537,11 +1537,3 @@ scikit_learn:
   model:
   - gs://ml-model
   output_standard_names: {}
-step_storage_variables:
-- specific_humidity
-- total_water
-step_tendency_variables:
-- specific_humidity
-- air_temperature
-- eastward_wind
-- northward_wind

--- a/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudge_to_obs_config_regression.out
+++ b/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudge_to_obs_config_regression.out
@@ -1721,11 +1721,3 @@ nudging: null
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 prephysics: null
 scikit_learn: null
-step_storage_variables:
-- specific_humidity
-- total_water
-step_tendency_variables:
-- specific_humidity
-- air_temperature
-- eastward_wind
-- northward_wind

--- a/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudging_config_regression.out
+++ b/workflows/prognostic_c48_run/_regtest_outputs/test_prepare_config.test_prepare_nudging_config_regression.out
@@ -1617,11 +1617,3 @@ nudging:
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 prephysics: null
 scikit_learn: null
-step_storage_variables:
-- specific_humidity
-- total_water
-step_tendency_variables:
-- specific_humidity
-- air_temperature
-- eastward_wind
-- northward_wind

--- a/workflows/prognostic_c48_run/docs/config-usage.rst
+++ b/workflows/prognostic_c48_run/docs/config-usage.rst
@@ -119,13 +119,11 @@ If no :py:attr:`UserConfig.diagnostics` section is provided in the ``minimal.yam
 default diagnostics
 are configured depending on whether ML, nudge-to-fine, nudge-to-obs, or baseline runs
 are chosen. To save custom diagnostics, provide a ``diagnostics`` section. To save 
-additional
-tendencies and storages across physics and nudging/ML time steps, add
-:py:attr:`UserConfig.step_tendency_variables` and
-:py:attr:`UserConfig.step_storage_variables` entries to specify these
-variables. Then add an additional output .zarr which includes among its
-variables the desired tendencies and/or path storages of these variables due
-to physics (``_due_to_fv3_physics``) and/or ML/nudging (``_due_to_python``).
+additional tendencies and storages across physics and nudging/ML time steps, include 
+variables named like ``tendency_of_{variable}_due_to_{step_name}`` or 
+``storage_of_{variable}_path_due_to_{step_name}`` where ``variable`` is the name
+of a state variable and ``step_name`` can be either ``fv3_physics`` or ``_python``
+(i.e. ML or nudging).
 
 Note that the diagnostic output named ``state_after_timestep.zarr`` is a special case;
 it can only be used to save variables that have getters in the wrapper.
@@ -136,15 +134,6 @@ being saved.
 
 .. code-block:: yaml
 
-    step_tendency_variables: 
-        - air_temperature
-        - specific_humidity
-        - eastward_wind
-        - northward_wind
-        - cloud_water_mixing_ratio
-    step_storage_variables: 
-        - specific_humidity
-        - cloud_water_mixing_ratio
     diagnostics:
     - name: step_diags.zarr
       chunks:

--- a/workflows/prognostic_c48_run/docs/config-usage.rst
+++ b/workflows/prognostic_c48_run/docs/config-usage.rst
@@ -122,7 +122,7 @@ are chosen. To save custom diagnostics, provide a ``diagnostics`` section. To sa
 additional tendencies and storages across physics and nudging/ML time steps, include 
 variables named like ``tendency_of_{variable}_due_to_{step_name}`` or 
 ``storage_of_{variable}_path_due_to_{step_name}`` where ``variable`` is the name
-of a state variable and ``step_name`` can be either ``fv3_physics`` or ``_python``
+of a state variable and ``step_name`` can be either ``fv3_physics`` or ``python``
 (i.e. ML or nudging).
 
 Note that the diagnostic output named ``state_after_timestep.zarr`` is a special case;

--- a/workflows/prognostic_c48_run/runtime/config.py
+++ b/workflows/prognostic_c48_run/runtime/config.py
@@ -30,11 +30,6 @@ class UserConfig:
         scikit_learn: a machine learning configuration
         nudging: nudge2fine configuration. Cannot be used if any scikit_learn model
             urls are specified.
-        step_tendency_variables: variables to compute the tendencies of.
-            These could in principle be inferred from the requested diagnostic
-            names.
-        step_storage_variables: variables to compute the storage of. Needed for certain
-            diagnostics.
     """
 
     diagnostics: List[DiagnosticFileConfig] = dataclasses.field(default_factory=list)
@@ -44,14 +39,6 @@ class UserConfig:
     prephysics: Optional[Union[PrescriberConfig, MachineLearningConfig]] = None
     scikit_learn: Optional[MachineLearningConfig] = None
     nudging: Optional[NudgingConfig] = None
-    step_tendency_variables: List[str] = dataclasses.field(
-        default_factory=lambda: list(
-            ("specific_humidity", "air_temperature", "eastward_wind", "northward_wind",)
-        )
-    )
-    step_storage_variables: List[str] = dataclasses.field(
-        default_factory=lambda: list(("specific_humidity", "total_water"))
-    )
 
 
 def get_config() -> UserConfig:

--- a/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/manager.py
@@ -1,7 +1,6 @@
 from typing import (
     Any,
     Sequence,
-    Container,
     Mapping,
     List,
     Union,
@@ -17,7 +16,7 @@ import xarray as xr
 import dataclasses
 
 from .fortran import FortranFileConfig
-from .time import TimeConfig, TimeContainer, All
+from .time import TimeConfig, TimeContainer
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +28,14 @@ class DiagnosticFileConfig:
     Attributes:
         name: filename of a zarr to store the data in, e.g., 'diags.zarr'.
             Paths are relative to the run-directory root.
-        variables: the variables to save. By default all available diagnostics
+        variables: the variables to save. By default no diagnostics
             are stored. Example: ``["air_temperature", "cos_zenith_angle"]``.
         times: the time configuration
         chunks: mapping of dimension names to chunk sizes
     """
 
     name: str
-    variables: Optional[Container] = None
+    variables: Sequence[str] = dataclasses.field(default_factory=list)
     times: TimeConfig = dataclasses.field(default_factory=lambda: TimeConfig())
     chunks: Mapping[str, int] = dataclasses.field(default_factory=dict)
 
@@ -50,7 +49,7 @@ class DiagnosticFileConfig:
         comm: Any,
     ) -> "DiagnosticFile":
         return DiagnosticFile(
-            variables=self.variables if self.variables else All(),
+            variables=self.variables,
             times=self.times.time_container(initial_time),
             monitor=fv3gfs.util.ZarrMonitor(self.name, partitioner, mpi_comm=comm),
         )
@@ -73,7 +72,7 @@ class DiagnosticFile:
 
     def __init__(
         self,
-        variables: Container,
+        variables: Sequence[str],
         monitor: fv3gfs.util.ZarrMonitor,
         times: TimeContainer,
     ):
@@ -81,10 +80,9 @@ class DiagnosticFile:
 
         Note:
 
-            The containers used for times and variables do not need to be
-            concrete lists or python sequences. They only need to satisfy the
-            abstract ``Container`` interface. Please see the special
-            containers for outputing times above:
+            The container used for times does not need to be a concrete list or python
+            sequence. It only need to satisfy the abstract ``Container`` interface.
+            Please see the special containers for outputting times above:
 
             - ``IntervalTimes``
             - ``SelectedTimes``
@@ -157,8 +155,8 @@ def get_diagnostic_files(
     initial_time: cftime.DatetimeJulian,
 ) -> List[DiagnosticFile]:
     """Initialize a list of diagnostic file objects from a configuration dictionary
-    Note- the default here is to save all the variables in the diagnostics.
-    The default set of variables can be overwritten by inserting a default diagnostics
+    Note- the default here is to save no variables in the diagnostics. This
+    can be overwritten by inserting a default diagnostics
     config entry for each runfile, e.g. ../prepare_config.py does this for
     the sklearn runfile.
 

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -28,7 +28,6 @@ from runtime.diagnostics.machine_learning import (
     precipitation_rate,
     precipitation_sum,
 )
-from runtime.diagnostics.time import All
 from runtime.steppers.machine_learning import (
     PureMLStepper,
     open_model,

--- a/workflows/prognostic_c48_run/runtime/loop.py
+++ b/workflows/prognostic_c48_run/runtime/loop.py
@@ -549,14 +549,12 @@ class MonitoredPhysicsTimeLoop(TimeLoop):
         """Get sequences of tendency and storage variables from diagnostics config."""
         tendency_variables = []
         storage_variables = []
-        explicit_diagnostics = [d for d in diagnostics if d.variables is not None]
-        for diag_file_config in explicit_diagnostics:
-            assert diag_file_config.variables is not None  # needed for mypy
+        for diag_file_config in diagnostics:
             for variable in diag_file_config.variables:
-                if variable.startswith("tendency_of"):
+                if variable.startswith("tendency_of") and "_due_to_" in variable:
                     short_name = variable.split("_due_to_")[0][len("tendency_of_") :]
                     tendency_variables.append(short_name)
-                elif variable.startswith("storage_of"):
+                elif variable.startswith("storage_of") and "_path_due_to_" in variable:
                     split_str = "_path_due_to_"
                     short_name = variable.split(split_str)[0][len("storage_of_") :]
                     storage_variables.append(short_name)

--- a/workflows/prognostic_c48_run/sklearn_runfile.py
+++ b/workflows/prognostic_c48_run/sklearn_runfile.py
@@ -34,12 +34,7 @@ if __name__ == "__main__":
     partitioner = util.CubedSpherePartitioner.from_namelist(runtime.get_namelist())
     setup_metrics_logger()
 
-    loop = MonitoredPhysicsTimeLoop(
-        config=config,
-        comm=comm,
-        tendency_variables=config.step_tendency_variables,
-        storage_variables=config.step_storage_variables,
-    )
+    loop = MonitoredPhysicsTimeLoop(config, comm=comm)
 
     diag_files = runtime.get_diagnostic_files(
         config.diagnostics, partitioner, comm, initial_time=loop.time

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -28,6 +28,24 @@ DIAGNOSTICS = [
         "name": "diags.zarr",
         "times": {"kind": "interval", "frequency": 900, "times": None},
     },
+    {
+        "name": "monitored_tendencies_and_storages.zarr",
+        "times": {"kind": "interval", "frequency": 900, "times": None},
+        "variables": [
+            "storage_of_specific_humidity_path_due_to_fv3_physics",
+            "storage_of_specific_humidity_path_due_to_python",
+            "storage_of_total_water_path_due_to_fv3_physics",
+            "storage_of_total_water_path_due_to_python",
+            "tendency_of_air_temperature_due_to_fv3_physics",
+            "tendency_of_air_temperature_due_to_python",
+            "tendency_of_eastward_wind_due_to_fv3_physics",
+            "tendency_of_eastward_wind_due_to_python",
+            "tendency_of_northward_wind_due_to_fv3_physics",
+            "tendency_of_northward_wind_due_to_python",
+            "tendency_of_specific_humidity_due_to_fv3_physics",
+            "tendency_of_specific_humidity_due_to_python",
+        ],
+    },
 ]
 
 
@@ -414,8 +432,7 @@ def get_ml_config(model_path):
     config = yaml.safe_load(default_fv3config)
     config["diagnostics"] = DIAGNOSTICS
     config["fortran_diagnostics"] = []
-    config["scikit_learn"] = {"model": [model_path], "zarr_output": "diags.zarr"}
-    config["step_storage_variables"] = ["specific_humidity", "total_water"]
+    config["scikit_learn"] = {"model": [model_path]}
     # use local paths in prognostic_run image. fv3config
     # downloads data. We should change this once the fixes in
     # https://github.com/VulcanClimateModeling/fv3gfs-python/pull/78 propagates

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -23,16 +23,34 @@ FORCING_PATH = BASE_FV3CONFIG_CACHE.joinpath("base_forcing", "v1.1")
 LOG_PATH = "statistics.txt"
 RUNFILE_PATH = "runfile.py"
 CHUNKS_PATH = "chunks.yaml"
-DIAGNOSTICS = [
+DIAGNOSTICS_ML = [
     {
         "name": "diags.zarr",
         "times": {"kind": "interval", "frequency": 900, "times": None},
-    },
-    {
-        "name": "monitored_tendencies_and_storages.zarr",
-        "times": {"kind": "interval", "frequency": 900, "times": None},
         "variables": [
+            "air_temperature",
+            "area",
+            "cnvprcp_after_physics",
+            "cnvprcp_after_python",
+            "column_integrated_dQ1_change_non_neg_sphum_constraint",
+            "column_integrated_dQ2_change_non_neg_sphum_constraint",
+            "column_integrated_dQu",
+            "column_integrated_dQv",
+            "dQ1",
+            "dQ2",
+            "dQu",
+            "dQv",
+            "evaporation",
+            "net_heating",
+            "net_moistening",
+            "physics_precip",
+            "pressure_thickness_of_atmospheric_layer",
+            "rank_updated_points",
+            "specific_humidity",
+            "storage_of_mass_due_to_fv3_physics",
+            "storage_of_mass_due_to_python",
             "storage_of_specific_humidity_path_due_to_fv3_physics",
+            "storage_of_specific_humidity_path_due_to_microphysics",
             "storage_of_specific_humidity_path_due_to_python",
             "storage_of_total_water_path_due_to_fv3_physics",
             "storage_of_total_water_path_due_to_python",
@@ -44,8 +62,49 @@ DIAGNOSTICS = [
             "tendency_of_northward_wind_due_to_python",
             "tendency_of_specific_humidity_due_to_fv3_physics",
             "tendency_of_specific_humidity_due_to_python",
+            "total_precip_after_physics",
+            "total_precipitation_rate",
+            "water_vapor_path",
         ],
-    },
+    }
+]
+DIAGNOSTICS_NUDGING = [
+    {
+        "name": "diags.zarr",
+        "times": {"kind": "interval", "frequency": 900, "times": None},
+        "variables": [
+            "air_temperature_reference",
+            "air_temperature_tendency_due_to_nudging",
+            "area",
+            "cnvprcp_after_physics",
+            "cnvprcp_after_python",
+            "evaporation",
+            "net_heating_due_to_nudging",
+            "net_moistening_due_to_nudging",
+            "physics_precip",
+            "specific_humidity_reference",
+            "specific_humidity_tendency_due_to_nudging",
+            "storage_of_mass_due_to_fv3_physics",
+            "storage_of_mass_due_to_python",
+            "storage_of_specific_humidity_path_due_to_fv3_physics",
+            "storage_of_specific_humidity_path_due_to_microphysics",
+            "storage_of_specific_humidity_path_due_to_python",
+            "storage_of_total_water_path_due_to_fv3_physics",
+            "storage_of_total_water_path_due_to_python",
+            "surface_temperature_reference",
+            "tendency_of_air_temperature_due_to_fv3_physics",
+            "tendency_of_air_temperature_due_to_python",
+            "tendency_of_eastward_wind_due_to_fv3_physics",
+            "tendency_of_eastward_wind_due_to_python",
+            "tendency_of_northward_wind_due_to_fv3_physics",
+            "tendency_of_northward_wind_due_to_python",
+            "tendency_of_specific_humidity_due_to_fv3_physics",
+            "tendency_of_specific_humidity_due_to_python",
+            "total_precip_after_physics",
+            "total_precipitation_rate",
+            "water_vapor_path",
+        ],
+    }
 ]
 
 
@@ -423,14 +482,14 @@ def _get_nudging_config(config_yaml: str, timestamp_dir: str):
 
 def get_nudging_config():
     config = _get_nudging_config(default_fv3config, "gs://" + IC_PATH.as_posix())
-    config["diagnostics"] = DIAGNOSTICS
+    config["diagnostics"] = DIAGNOSTICS_NUDGING
     config["fortran_diagnostics"] = []
     return config
 
 
 def get_ml_config(model_path):
     config = yaml.safe_load(default_fv3config)
-    config["diagnostics"] = DIAGNOSTICS
+    config["diagnostics"] = DIAGNOSTICS_ML
     config["fortran_diagnostics"] = []
     config["scikit_learn"] = {"model": [model_path]}
     # use local paths in prognostic_run image. fv3config

--- a/workflows/prognostic_c48_run/tests/test_regression.py
+++ b/workflows/prognostic_c48_run/tests/test_regression.py
@@ -23,89 +23,6 @@ FORCING_PATH = BASE_FV3CONFIG_CACHE.joinpath("base_forcing", "v1.1")
 LOG_PATH = "statistics.txt"
 RUNFILE_PATH = "runfile.py"
 CHUNKS_PATH = "chunks.yaml"
-DIAGNOSTICS_ML = [
-    {
-        "name": "diags.zarr",
-        "times": {"kind": "interval", "frequency": 900, "times": None},
-        "variables": [
-            "air_temperature",
-            "area",
-            "cnvprcp_after_physics",
-            "cnvprcp_after_python",
-            "column_integrated_dQ1_change_non_neg_sphum_constraint",
-            "column_integrated_dQ2_change_non_neg_sphum_constraint",
-            "column_integrated_dQu",
-            "column_integrated_dQv",
-            "dQ1",
-            "dQ2",
-            "dQu",
-            "dQv",
-            "evaporation",
-            "net_heating",
-            "net_moistening",
-            "physics_precip",
-            "pressure_thickness_of_atmospheric_layer",
-            "rank_updated_points",
-            "specific_humidity",
-            "storage_of_mass_due_to_fv3_physics",
-            "storage_of_mass_due_to_python",
-            "storage_of_specific_humidity_path_due_to_fv3_physics",
-            "storage_of_specific_humidity_path_due_to_microphysics",
-            "storage_of_specific_humidity_path_due_to_python",
-            "storage_of_total_water_path_due_to_fv3_physics",
-            "storage_of_total_water_path_due_to_python",
-            "tendency_of_air_temperature_due_to_fv3_physics",
-            "tendency_of_air_temperature_due_to_python",
-            "tendency_of_eastward_wind_due_to_fv3_physics",
-            "tendency_of_eastward_wind_due_to_python",
-            "tendency_of_northward_wind_due_to_fv3_physics",
-            "tendency_of_northward_wind_due_to_python",
-            "tendency_of_specific_humidity_due_to_fv3_physics",
-            "tendency_of_specific_humidity_due_to_python",
-            "total_precip_after_physics",
-            "total_precipitation_rate",
-            "water_vapor_path",
-        ],
-    }
-]
-DIAGNOSTICS_NUDGING = [
-    {
-        "name": "diags.zarr",
-        "times": {"kind": "interval", "frequency": 900, "times": None},
-        "variables": [
-            "air_temperature_reference",
-            "air_temperature_tendency_due_to_nudging",
-            "area",
-            "cnvprcp_after_physics",
-            "cnvprcp_after_python",
-            "evaporation",
-            "net_heating_due_to_nudging",
-            "net_moistening_due_to_nudging",
-            "physics_precip",
-            "specific_humidity_reference",
-            "specific_humidity_tendency_due_to_nudging",
-            "storage_of_mass_due_to_fv3_physics",
-            "storage_of_mass_due_to_python",
-            "storage_of_specific_humidity_path_due_to_fv3_physics",
-            "storage_of_specific_humidity_path_due_to_microphysics",
-            "storage_of_specific_humidity_path_due_to_python",
-            "storage_of_total_water_path_due_to_fv3_physics",
-            "storage_of_total_water_path_due_to_python",
-            "surface_temperature_reference",
-            "tendency_of_air_temperature_due_to_fv3_physics",
-            "tendency_of_air_temperature_due_to_python",
-            "tendency_of_eastward_wind_due_to_fv3_physics",
-            "tendency_of_eastward_wind_due_to_python",
-            "tendency_of_northward_wind_due_to_fv3_physics",
-            "tendency_of_northward_wind_due_to_python",
-            "tendency_of_specific_humidity_due_to_fv3_physics",
-            "tendency_of_specific_humidity_due_to_python",
-            "total_precip_after_physics",
-            "total_precipitation_rate",
-            "water_vapor_path",
-        ],
-    }
-]
 
 
 class ConfigEnum:
@@ -482,14 +399,95 @@ def _get_nudging_config(config_yaml: str, timestamp_dir: str):
 
 def get_nudging_config():
     config = _get_nudging_config(default_fv3config, "gs://" + IC_PATH.as_posix())
-    config["diagnostics"] = DIAGNOSTICS_NUDGING
+    config["diagnostics"] = [
+        {
+            "name": "diags.zarr",
+            "times": {"kind": "interval", "frequency": 900, "times": None},
+            "variables": [
+                "air_temperature_reference",
+                "air_temperature_tendency_due_to_nudging",
+                "area",
+                "cnvprcp_after_physics",
+                "cnvprcp_after_python",
+                "evaporation",
+                "net_heating_due_to_nudging",
+                "net_moistening_due_to_nudging",
+                "physics_precip",
+                "specific_humidity_reference",
+                "specific_humidity_tendency_due_to_nudging",
+                "storage_of_mass_due_to_fv3_physics",
+                "storage_of_mass_due_to_python",
+                "storage_of_specific_humidity_path_due_to_fv3_physics",
+                "storage_of_specific_humidity_path_due_to_microphysics",
+                "storage_of_specific_humidity_path_due_to_python",
+                "storage_of_total_water_path_due_to_fv3_physics",
+                "storage_of_total_water_path_due_to_python",
+                "surface_temperature_reference",
+                "tendency_of_air_temperature_due_to_fv3_physics",
+                "tendency_of_air_temperature_due_to_python",
+                "tendency_of_eastward_wind_due_to_fv3_physics",
+                "tendency_of_eastward_wind_due_to_python",
+                "tendency_of_northward_wind_due_to_fv3_physics",
+                "tendency_of_northward_wind_due_to_python",
+                "tendency_of_specific_humidity_due_to_fv3_physics",
+                "tendency_of_specific_humidity_due_to_python",
+                "total_precip_after_physics",
+                "total_precipitation_rate",
+                "water_vapor_path",
+            ],
+        }
+    ]
     config["fortran_diagnostics"] = []
     return config
 
 
 def get_ml_config(model_path):
     config = yaml.safe_load(default_fv3config)
-    config["diagnostics"] = DIAGNOSTICS_ML
+    config["diagnostics"] = [
+        {
+            "name": "diags.zarr",
+            "times": {"kind": "interval", "frequency": 900, "times": None},
+            "variables": [
+                "air_temperature",
+                "area",
+                "cnvprcp_after_physics",
+                "cnvprcp_after_python",
+                "column_integrated_dQ1_change_non_neg_sphum_constraint",
+                "column_integrated_dQ2_change_non_neg_sphum_constraint",
+                "column_integrated_dQu",
+                "column_integrated_dQv",
+                "dQ1",
+                "dQ2",
+                "dQu",
+                "dQv",
+                "evaporation",
+                "net_heating",
+                "net_moistening",
+                "physics_precip",
+                "pressure_thickness_of_atmospheric_layer",
+                "rank_updated_points",
+                "specific_humidity",
+                "storage_of_mass_due_to_fv3_physics",
+                "storage_of_mass_due_to_python",
+                "storage_of_specific_humidity_path_due_to_fv3_physics",
+                "storage_of_specific_humidity_path_due_to_microphysics",
+                "storage_of_specific_humidity_path_due_to_python",
+                "storage_of_total_water_path_due_to_fv3_physics",
+                "storage_of_total_water_path_due_to_python",
+                "tendency_of_air_temperature_due_to_fv3_physics",
+                "tendency_of_air_temperature_due_to_python",
+                "tendency_of_eastward_wind_due_to_fv3_physics",
+                "tendency_of_eastward_wind_due_to_python",
+                "tendency_of_northward_wind_due_to_fv3_physics",
+                "tendency_of_northward_wind_due_to_python",
+                "tendency_of_specific_humidity_due_to_fv3_physics",
+                "tendency_of_specific_humidity_due_to_python",
+                "total_precip_after_physics",
+                "total_precipitation_rate",
+                "water_vapor_path",
+            ],
+        }
+    ]
     config["fortran_diagnostics"] = []
     config["scikit_learn"] = {"model": [model_path]}
     # use local paths in prognostic_run image. fv3config


### PR DESCRIPTION
Currently one must redundantly specify certain variable names in `step_tendency_variables` or `step_storage_variables` sections of the user config as well as list the relevant name in the appropriate diagnostics file config. This PR makes the former be inferred from the latter.

Refactored public API:
- `step_storage_variables` and `step_tendency_variables` deleted from `UserConfig`
- the default for `DiagnosticsFileConfig.variables` is now an empty list (instead of `All` container)

Significant internal changes:
- the internal `self._storage_variables` and `self._tendency_variables` are now inferred from the provided diagnostics configurations

- [ ] Tests added

Resolves first bullet point in #1164 
