### PR TITLE
Keep attributes when interpolating nudging data

### DIFF
--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -200,9 +200,10 @@ def _average_states(state_0: State, state_1: State, weight: float) -> State:
     out = {}
     for key in common_keys:
         if isinstance(state_1[key], xr.DataArray):
-            out[key] = (
-                state_0[key] * weight + (1 - weight) * state_1[key]  # type: ignore
-            )
+            with xr.set_options(keep_attrs=True):
+                out[key] = (
+                    state_0[key] * weight + (1 - weight) * state_1[key]  # type: ignore
+                )
     return out
 
 

--- a/workflows/prognostic_c48_run/tests/test_nudging.py
+++ b/workflows/prognostic_c48_run/tests/test_nudging.py
@@ -33,15 +33,17 @@ def test__sst_from_reference():
 def test__time_interpolate_func_has_correct_value(fraction):
     initial_time = cftime.DatetimeJulian(2016, 1, 1)
     frequency = timedelta(hours=3)
+    attrs = {"units": "foo"}
 
     def func(time):
         value = float(time - initial_time > timedelta(hours=1.5))
-        return {"a": xr.DataArray(data=np.array([value]), dims=["x"])}
+        return {"a": xr.DataArray(data=np.array([value]), dims=["x"], attrs=attrs)}
 
     myfunc = _time_interpolate_func(func, frequency, initial_time)
     ans = myfunc(initial_time + frequency * fraction)
     assert isinstance(ans["a"], xr.DataArray)
     assert float(ans["a"].values) == pytest.approx(fraction)
+    assert ans["a"].attrs == attrs
 
 
 def test__time_interpolate_func_only_grabs_correct_points():


### PR DESCRIPTION
When running with a timestep shorter than the frequency of the available nudging data we must interpolate the reference state.  Currently the attributes, such as the units of a variable, are lost in this interpolation step.  This can lead to problems when storing the reference state in a zarr store, as at some times the reference state variables have units attributes, but at other times they do not, e.g. from a recent prognostic run:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.6/dist-packages/mpi4py/__main__.py", line 7, in <module>
    main()
  File "/usr/local/lib/python3.6/dist-packages/mpi4py/run.py", line 196, in main
    run_command_line(args)
  File "/usr/local/lib/python3.6/dist-packages/mpi4py/run.py", line 47, in run_command_line
    run_path(sys.argv[0], run_name='__main__')
  File "/usr/lib/python3.6/runpy.py", line 263, in run_path
    pkg_name=pkg_name, script_name=fname)
  File "/usr/lib/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "runfile.py", line 63, in <module>
    diag_file.flush()
  File "/fv3net/workflows/prognostic_c48_run/runtime/diagnostics/manager.py", line 145, in flush
    self._monitor.store(quantities)
  File "/usr/local/lib/python3.6/dist-packages/fv3gfs/util/zarr_monitor.py", line 107, in store
    self._writers[name].append(quantity)  # type: ignore[index]
  File "/usr/local/lib/python3.6/dist-packages/fv3gfs/util/zarr_monitor.py", line 168, in append
    self._ensure_compatible_attrs(quantity)
  File "/usr/local/lib/python3.6/dist-packages/fv3gfs/util/zarr_monitor.py", line 213, in _ensure_compatible_attrs
    f"value for {self.name} with attrs {new_attrs} "
ValueError: value for air_temperature_reference with attrs {'_ARRAY_DIMENSIONS': ['time', 'tile', 'z', 'y', 'x'], 'units': 'degK'} does not match previously stored attrs {'_ARRAY_DIMENSIONS': ['time', 'tile', 'z', 'y', 'x'], 'units': 'unknown'}
```

- [x] Tests added

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

