### PR TITLE
Offline diags: allow 1 based tile indexing

### DIFF
--- a/workflows/offline_ml_diags/offline_ml_diags/_helpers.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/_helpers.py
@@ -136,7 +136,7 @@ def load_grid_info(res: str = "c48"):
     wind_rotation = catalog[f"wind_rotation/{res}"].read()
     land_sea_mask = catalog[f"landseamask/{res}"].read()
     grid_info = xr.merge([grid, wind_rotation, land_sea_mask])
-    return safe.get_variables(grid_info, GRID_INFO_VARS)
+    return safe.get_variables(grid_info, GRID_INFO_VARS).drop("tile")
 
 
 def write_report(


### PR DESCRIPTION
This change avoids issues with outer joins that arise when the training data has tile coords starting at 1 and the grid has tile coords that start at 0.