### PR TITLE
remove pin of fsspec to 0.* in synth

### DIFF
--- a/external/synth/setup.py
+++ b/external/synth/setup.py
@@ -17,7 +17,7 @@ setup(
     entry_points={"console_scripts": ["synth-save-schema=synth.clis:save_schema"]},
     install_requires=[
         "dask==2.*,>=2.15.0",
-        "fsspec==0.*,>=0.7.3",
+        "fsspec>=0.7.3",
         "toolz==0.*,>=0.10.0",
         "xarray==0.*,>=0.15.1",
         "zarr==2.*,>=2.4.0",


### PR DESCRIPTION
Fsspec moved from 0.X.X versioning to YYYY.MM.DD versioning, which breaks our fsspec==0.* constraint. This PR removes that constraint.

Requirement changes:
- synth no longer requires `fsspec==0.*`, keeping only the `>=` version requirement