### PR TITLE
vcm.catalog: Update c3072 verification for corrected pressure level U200, U850 

### DIFF
--- a/external/vcm/vcm/catalog.yaml
+++ b/external/vcm/vcm/catalog.yaml
@@ -188,7 +188,7 @@ sources:
       storage_options:
         project: 'vcm-ml'
         access: read_only
-      urlpath: "gs://vcm-ml-intermediate/2020-05-coarsen-c384-diagnostics/coarsen_diagnostics/atmos_8xdaily_add_vars.zarr"
+      urlpath: "gs://vcm-ml-intermediate/2020-05-coarsen-c384-diagnostics/coarsen_diagnostics/atmos_8xdaily_add_vars_corrected_wind.zarr"
       consolidated: True
 
   GFS_analysis_T85_2015_2016:


### PR DESCRIPTION
The previous catalog entry for `40day_c48_atmos_8xdaily_additional_vars_may2020`  had incorrect U200/U850 data because the wind rotation matrix at the time was off by a factor of 0.5. This update points to a corrected dataset.

