### PR TITLE
Always use setup.cfg in precommit flake8 hook 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       name: flake8
       language_version: python3
       exclude: "__init__.py"
+      args: ["--config=setup.cfg"]
     - id: flake8
       name: flake8 __init__.py files
       files: "__init__.py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       name: flake8
       language_version: python3
       exclude: "__init__.py"
-      args: ["--config=setup.cfg"]
+      args: [--config, setup.cfg]
     - id: flake8
       name: flake8 __init__.py files
       files: "__init__.py"


### PR DESCRIPTION
For some reason, the flake8 precommit hook was not consistently applying the config settings in `setup.cfg`, which resulted in commit failures due to it using the default max-line-length of 79 chars (`black` autoreformats to a max of 88 chars). Telling the flake8 hook explicitly to use `setup.cfg` seems to fix this.