### PR TITLE
More flexible prognostic run report CLI

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,4 @@ norecursedirs =
 
 markers =
     regression: marks regression tests (deselect with '-m "not regression"')
+    network: marks tests requiring network access

--- a/workflows/prognostic_run_diags/docs/usage.rst
+++ b/workflows/prognostic_run_diags/docs/usage.rst
@@ -43,4 +43,12 @@ The report can be generated with
 
    prognostic_run_diags report report_data output_report_location
 
+To make a report from runs that are not in a combined folder like
+``report_data`` above, you can use the alternative command::
+
+   prognostic_run_diags report-from-urls \
+      -o <output_path> \
+      path/to/baseline_run_reports/ \
+      path/to/prognostic_run_reports
+
 See :ref:`cli` for details about the options available for the above commands.

--- a/workflows/prognostic_run_diags/docs/usage.rst
+++ b/workflows/prognostic_run_diags/docs/usage.rst
@@ -48,7 +48,7 @@ To make a report from runs that are not in a combined folder like
 
    prognostic_run_diags report-from-urls \
       -o <output_path> \
-      path/to/baseline_run_reports/ \
-      path/to/prognostic_run_reports
+      path/to/baseline_run_diags \
+      path/to/prognostic_run_diags
 
 See :ref:`cli` for details about the options available for the above commands.

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -2,7 +2,7 @@
 
 """
 import json
-from typing import Iterable, Hashable, Sequence, Tuple, Any, Set
+from typing import Iterable, Hashable, Sequence, Tuple, Any, Set, Mapping
 import os
 import xarray as xr
 import numpy as np
@@ -179,7 +179,7 @@ class RunMetrics:
 def load_metrics(fs, bucket) -> pd.DataFrame:
     """Load the metrics from a bucket"""
     rundirs = detect_rundirs(bucket, fs)
-    metrics = _load_metrics(bucket, rundirs)
+    metrics = _load_metrics(rundirs)
     metric_table = pd.DataFrame.from_records(_yield_metric_rows(metrics))
     run_table = parse_rundirs(rundirs)
     return pd.merge(run_table, metric_table, on="run")
@@ -188,7 +188,7 @@ def load_metrics(fs, bucket) -> pd.DataFrame:
 def load_diagnostics(fs, bucket) -> Tuple[Metadata, Diagnostics]:
     """Load metadata and merged diagnostics from a bucket"""
     rundirs = detect_rundirs(bucket, fs)
-    diags = _load_diags(bucket, rundirs)
+    diags = _load_diags(rundirs)
     run_table_lookup = parse_rundirs(rundirs)
     diagnostics = [
         ds.assign_attrs(run=key, **run_table_lookup.loc[key])
@@ -213,14 +213,13 @@ def find_movie_links(fs, bucket, domain=PUBLIC_GCS_DOMAIN):
 
     # TODO refactor to split out I/O from html generation
     movie_links = {}
-    for rundir in rundirs:
-        movie_paths = fs.glob(os.path.join(bucket, rundir, "*.mp4"))
-        for gcs_path in movie_paths:
+    for name, folder in rundirs.items():
+        for movie_name, gcs_path in folder.movie_links:
             movie_name = os.path.basename(gcs_path)
             if movie_name not in movie_links:
                 movie_links[movie_name] = []
             public_url = os.path.join(domain, gcs_path)
-            movie_links[movie_name].append((public_url, rundir))
+            movie_links[movie_name].append((public_url, name))
     return movie_links
 
 
@@ -233,24 +232,53 @@ def _longest_run(diagnostics: Iterable[xr.Dataset]) -> xr.Dataset:
     return longest_ds
 
 
-def detect_rundirs(bucket: str, fs: fsspec.AbstractFileSystem):
+@dataclass
+class DiagnosticFolder:
+    """Represents the output of compute diagnostics"""
+
+    fs: fsspec.AbstractFileSystem
+    path: str
+
+    @property
+    def metrics(self):
+        path = os.path.join(self.path, "metrics.json")
+        return json.loads(self.fs.cat(path))
+
+    @property
+    def diagnostics(self) -> xr.Dataset:
+        path = os.path.join(self.path, "diags.nc")
+        with tempfile.NamedTemporaryFile() as f:
+            self.fs.get(path, f.name)
+            return xr.open_dataset(f.name, engine="h5netcdf").compute()
+
+    @property
+    def movie_links(self, domain=PUBLIC_GCS_DOMAIN):
+        movie_paths = self.fs.glob(os.path.join(self.path, "*.mp4"))
+        for gcs_path in movie_paths:
+            movie_name = os.path.basename(gcs_path)
+            public_url = os.path.join(domain, gcs_path)
+            yield movie_name, public_url
+
+
+def detect_rundirs(
+    bucket: str, fs: fsspec.AbstractFileSystem
+) -> Mapping[str, DiagnosticFolder]:
     diag_ncs = fs.glob(os.path.join(bucket, "*", "diags.nc"))
     if len(diag_ncs) < 2:
         raise ValueError(
             "Plots require more than 1 diagnostic directory in"
             f" {bucket} for holoviews plots to display correctly."
         )
-    return [Path(url).parent.name for url in diag_ncs]
+    return {
+        Path(url).parent.name: DiagnosticFolder(fs, Path(url).parent.as_posix())
+        for url in diag_ncs
+    }
 
 
-def _load_diags(bucket, rundirs):
+def _load_diags(rundirs: Mapping[str, DiagnosticFolder]):
     metrics = {}
-    for rundir in rundirs:
-        path = os.path.join(bucket, rundir, "diags.nc")
-        fs = fsspec.get_fs_token_paths(bucket)[0]
-        with tempfile.NamedTemporaryFile() as f:
-            fs.get(path, f.name)
-            metrics[rundir] = xr.open_dataset(f.name, engine="h5netcdf").compute()
+    for rundir, diag_folder in rundirs.items():
+        metrics[rundir] = diag_folder.diagnostics
     return metrics
 
 
@@ -267,13 +295,10 @@ def _yield_metric_rows(metrics):
             }
 
 
-def _load_metrics(bucket, rundirs):
+def _load_metrics(rundirs):
     metrics = {}
-    for rundir in rundirs:
-        path = os.path.join(bucket, rundir, "metrics.json")
-        with fsspec.open(path, "rb") as f:
-            metrics[rundir] = json.load(f)
-
+    for rundir, diag_folder in rundirs.items():
+        metrics[rundir] = diag_folder.metrics
     return metrics
 
 

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -25,24 +25,25 @@ Metadata = Any
 
 @dataclass
 class ComputedDiagnosticsList:
-    """Represents a list of computed diagnostics
-
-    Attrs:
-        folder: Mapping[str]
-        url: URL to directory containing rundirs as subdirectories.
-            "rundirs". rundirs are subdirectories of this bucket. They each
-            contain diags.nc, metrics.json, and .mp4 files.
-    """
-
     folders: Mapping[str, "DiagnosticFolder"]
 
     @staticmethod
-    def from_url(url: str) -> "ComputedDiagnosticsList":
+    def from_directory(url: str) -> "ComputedDiagnosticsList":
+        """Open a directory of computed diagnostics
+
+        Args:
+            url: URL to directory containing rundirs as subdirectories.
+                "rundirs". rundirs are subdirectories of this bucket. They each
+                contain diags.nc, metrics.json, and .mp4 files.
+        """
         fs, _, _ = fsspec.get_fs_token_paths(url)
         return ComputedDiagnosticsList(detect_folders(url, fs))
 
     @staticmethod
     def from_urls(urls: Sequence[str]) -> "ComputedDiagnosticsList":
+        """Open computed diagnostics at the specified urls
+        """
+
         def url_to_folder(url):
             fs, _, path = fsspec.get_fs_token_paths(url)
             return DiagnosticFolder(fs, path[0])

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -41,6 +41,16 @@ class ComputedDiagnosticsList:
         fs, _, _ = fsspec.get_fs_token_paths(url)
         return ComputedDiagnosticsList(detect_folders(url, fs))
 
+    @staticmethod
+    def from_urls(urls: Sequence[str]) -> "ComputedDiagnosticsList":
+        def url_to_folder(url):
+            fs, _, path = fsspec.get_fs_token_paths(url)
+            return DiagnosticFolder(fs, path[0])
+
+        return ComputedDiagnosticsList(
+            {str(k): url_to_folder(url) for k, url in enumerate(urls)}
+        )
+
     def load_metrics(self) -> "RunMetrics":
         return RunMetrics(load_metrics(self.folders))
 

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -454,7 +454,7 @@ def register_parser(subparsers):
 
 
 def main(args):
-    computed_diagnostics = ComputedDiagnosticsList.from_url(args.input)
+    computed_diagnostics = ComputedDiagnosticsList.from_directory(args.input)
     make_report(computed_diagnostics, args.output)
 
 

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -426,7 +426,7 @@ def register_parser(subparsers):
 
 def main(args):
 
-    computed_diagnostics = ComputedDiagnosticsList(url=args.input)
+    computed_diagnostics = ComputedDiagnosticsList.from_url(args.input)
     metrics = computed_diagnostics.load_metrics()
     movie_links = computed_diagnostics.find_movie_links()
     metadata, diagnostics = computed_diagnostics.load_diagnostics()

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -433,12 +433,14 @@ def make_report(computed_diagnostics: ComputedDiagnosticsList, output):
         upload(html, os.path.join(output, filename))
 
 
-def register_parser(subparsers):
+def _register_report(subparsers):
     parser = subparsers.add_parser("report", help="Generate a static html report.")
     parser.add_argument("input", help="Directory containing multiple run diagnostics.")
     parser.add_argument("output", help="Location to save report html files.")
     parser.set_defaults(func=main)
 
+
+def _register_report_from_urls(subparsers):
     parser = subparsers.add_parser(
         "report-from-urls",
         help="Generate a static html report from list of diagnostics.",
@@ -449,8 +451,15 @@ def register_parser(subparsers):
         "increasing numbers in report.",
         nargs="+",
     )
-    parser.add_argument("-o", "--output", help="Location to save report html files.")
+    parser.add_argument(
+        "-o", "--output", help="Location to save report html files.", required=True
+    )
     parser.set_defaults(func=main_new)
+
+
+def register_parser(subparsers):
+    _register_report(subparsers)
+    _register_report_from_urls(subparsers)
 
 
 def main(args):

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -417,16 +417,7 @@ def render_links(link_dict):
     }
 
 
-def register_parser(subparsers):
-    parser = subparsers.add_parser("report", help="Generate a static html report.")
-    parser.add_argument("input", help="Directory containing multiple run diagnostics.")
-    parser.add_argument("output", help="Location to save report html files.")
-    parser.set_defaults(func=main)
-
-
-def main(args):
-
-    computed_diagnostics = ComputedDiagnosticsList.from_url(args.input)
+def make_report(computed_diagnostics: ComputedDiagnosticsList, output):
     metrics = computed_diagnostics.load_metrics()
     movie_links = computed_diagnostics.find_movie_links()
     metadata, diagnostics = computed_diagnostics.load_diagnostics()
@@ -439,7 +430,37 @@ def main(args):
     }
 
     for filename, html in pages.items():
-        upload(html, os.path.join(args.output, filename))
+        upload(html, os.path.join(output, filename))
+
+
+def register_parser(subparsers):
+    parser = subparsers.add_parser("report", help="Generate a static html report.")
+    parser.add_argument("input", help="Directory containing multiple run diagnostics.")
+    parser.add_argument("output", help="Location to save report html files.")
+    parser.set_defaults(func=main)
+
+    parser = subparsers.add_parser(
+        "report-from-urls",
+        help="Generate a static html report from list of diagnostics.",
+    )
+    parser.add_argument(
+        "inputs",
+        help="Folders containing diags.nc. Will be labeled with "
+        "increasing numbers in report.",
+        nargs="+",
+    )
+    parser.add_argument("-o", "--output", help="Location to save report html files.")
+    parser.set_defaults(func=main_new)
+
+
+def main(args):
+    computed_diagnostics = ComputedDiagnosticsList.from_url(args.input)
+    make_report(computed_diagnostics, args.output)
+
+
+def main_new(args):
+    computed_diagnostics = ComputedDiagnosticsList.from_urls(args.inputs)
+    make_report(computed_diagnostics, args.output)
 
 
 if __name__ == "__main__":

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -150,3 +150,31 @@ def test_RunMetrics_get_metric_value_missing():
 def test_RunMetrics_get_metric_units():
     metrics = RunMetrics(metrics_df)
     assert metrics.get_metric_units("rmse_of_time_mean", "precip", "run1") == "mm/day"
+
+
+@pytest.fixture()
+def url():
+    # this data might get out of date if it does we should replace it with synth
+    # data
+    return "gs://vcm-ml-public/argo/2021-05-05-compare-n2o-resolution-a8290d64ce4f/"
+
+
+@pytest.mark.network
+def test_ComputeDiagnosticsList_load_diagnostics(url):
+    diags = ComputedDiagnosticsList(url)
+    meta, diags = diags.load_diagnostics()
+    assert isinstance(diags, RunDiagnostics)
+
+
+@pytest.mark.network
+def test_ComputeDiagnosticsList_load_metrics(url):
+    diags = ComputedDiagnosticsList(url)
+    meta = diags.load_metrics()
+    assert isinstance(meta, RunMetrics)
+
+
+@pytest.mark.network
+def test_ComputeDiagnosticsList_find_movie_links(url):
+    diags = ComputedDiagnosticsList(url)
+    meta = diags.find_movie_links()
+    assert len(meta) == 0

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -40,12 +40,8 @@ def test_detect_folders(tmpdir):
         assert isinstance(result[found_dir], DiagnosticFolder)
 
 
-def test_ComputedDiagnosticsList_from_urls(tmpdir):
-
+def test_ComputedDiagnosticsList_from_urls():
     rundirs = ["rundir1", "rundir2"]
-    for rdir in rundirs:
-        tmpdir.mkdir(rdir).join("diags.nc").write("foobar")
-
     result = ComputedDiagnosticsList.from_urls(rundirs)
 
     assert len(result.folders) == 2

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -74,7 +74,7 @@ def test_get_movie_links(tmpdir):
 
     tmpdir.join(rdirs[0]).join("movie2.mp4").write("foobar")
 
-    result = ComputedDiagnosticsList.from_url(str(tmpdir)).find_movie_links()
+    result = ComputedDiagnosticsList.from_directory(str(tmpdir)).find_movie_links()
 
     assert "movie1.mp4" in result
     assert "movie2.mp4" in result
@@ -176,20 +176,20 @@ def url():
 
 @pytest.mark.network
 def test_ComputeDiagnosticsList_load_diagnostics(url):
-    diags = ComputedDiagnosticsList.from_url(url)
+    diags = ComputedDiagnosticsList.from_directory(url)
     meta, diags = diags.load_diagnostics()
     assert isinstance(diags, RunDiagnostics)
 
 
 @pytest.mark.network
 def test_ComputeDiagnosticsList_load_metrics(url):
-    diags = ComputedDiagnosticsList.from_url(url)
+    diags = ComputedDiagnosticsList.from_directory(url)
     meta = diags.load_metrics()
     assert isinstance(meta, RunMetrics)
 
 
 @pytest.mark.network
 def test_ComputeDiagnosticsList_find_movie_links(url):
-    diags = ComputedDiagnosticsList.from_url(url)
+    diags = ComputedDiagnosticsList.from_directory(url)
     meta = diags.find_movie_links()
     assert len(meta) == 0

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -12,6 +12,7 @@ from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     detect_rundirs,
     RunDiagnostics,
     RunMetrics,
+    DiagnosticFolder,
 )
 
 
@@ -36,6 +37,7 @@ def test_detect_rundirs(tmpdir):
     assert len(result) == 2
     for found_dir in result:
         assert found_dir in rundirs
+        assert isinstance(result[found_dir], DiagnosticFolder)
 
 
 def test_detect_rundirs_fail_less_than_2(tmpdir):

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -9,7 +9,7 @@ import xarray
 from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     ComputedDiagnosticsList,
     _parse_metadata,
-    detect_rundirs,
+    detect_folders,
     RunDiagnostics,
     RunMetrics,
     DiagnosticFolder,
@@ -22,7 +22,7 @@ def test__parse_metadata():
     assert out == {"run": run, "baseline": True}
 
 
-def test_detect_rundirs(tmpdir):
+def test_detect_folders(tmpdir):
 
     fs = fsspec.filesystem("file")
 
@@ -32,7 +32,7 @@ def test_detect_rundirs(tmpdir):
 
     tmpdir.mkdir("not_a_rundir").join("useless_file.txt").write("useless!")
 
-    result = detect_rundirs(tmpdir, fs)
+    result = detect_folders(tmpdir, fs)
 
     assert len(result) == 2
     for found_dir in result:
@@ -40,14 +40,14 @@ def test_detect_rundirs(tmpdir):
         assert isinstance(result[found_dir], DiagnosticFolder)
 
 
-def test_detect_rundirs_fail_less_than_2(tmpdir):
+def test_detect_folders_fail_less_than_2(tmpdir):
 
     fs = fsspec.filesystem("file")
 
     tmpdir.mkdir("rundir1").join("diags.nc").write("foobar")
 
     with pytest.raises(ValueError):
-        detect_rundirs(tmpdir, fs)
+        detect_folders(tmpdir, fs)
 
 
 def test_get_movie_links(tmpdir):
@@ -61,7 +61,7 @@ def test_get_movie_links(tmpdir):
 
     tmpdir.join(rdirs[0]).join("movie2.mp4").write("foobar")
 
-    result = ComputedDiagnosticsList(str(tmpdir)).find_movie_links()
+    result = ComputedDiagnosticsList.from_url(str(tmpdir)).find_movie_links()
 
     assert "movie1.mp4" in result
     assert "movie2.mp4" in result
@@ -163,20 +163,20 @@ def url():
 
 @pytest.mark.network
 def test_ComputeDiagnosticsList_load_diagnostics(url):
-    diags = ComputedDiagnosticsList(url)
+    diags = ComputedDiagnosticsList.from_url(url)
     meta, diags = diags.load_diagnostics()
     assert isinstance(diags, RunDiagnostics)
 
 
 @pytest.mark.network
 def test_ComputeDiagnosticsList_load_metrics(url):
-    diags = ComputedDiagnosticsList(url)
+    diags = ComputedDiagnosticsList.from_url(url)
     meta = diags.load_metrics()
     assert isinstance(meta, RunMetrics)
 
 
 @pytest.mark.network
 def test_ComputeDiagnosticsList_find_movie_links(url):
-    diags = ComputedDiagnosticsList(url)
+    diags = ComputedDiagnosticsList.from_url(url)
     meta = diags.find_movie_links()
     assert len(meta) == 0

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -40,6 +40,19 @@ def test_detect_folders(tmpdir):
         assert isinstance(result[found_dir], DiagnosticFolder)
 
 
+def test_ComputedDiagnosticsList_from_urls(tmpdir):
+
+    rundirs = ["rundir1", "rundir2"]
+    for rdir in rundirs:
+        tmpdir.mkdir(rdir).join("diags.nc").write("foobar")
+
+    result = ComputedDiagnosticsList.from_urls(rundirs)
+
+    assert len(result.folders) == 2
+    assert isinstance(result.folders["0"], DiagnosticFolder)
+    assert isinstance(result.folders["1"], DiagnosticFolder)
+
+
 def test_detect_folders_fail_less_than_2(tmpdir):
 
     fs = fsspec.filesystem("file")


### PR DESCRIPTION
The prognostic run report only works with computed diagnostics stored in
a single directory. This was inflexible and coupled the data storage
particulars to the generated report.

Add a new CLI which allows generating a list of diagnostics from several
paths. It works like this:

    prognostic_run_diags report-dirs -o report $base/c384-baseline $base/c48-baseline


The runs are labeled by digits in the same order as the command line arguments. e.g. 1 2 3. With these refactors, it should be easy to change this.

Example here: https://storage.googleapis.com/vcm-ml-public/noahb/pr-1209/example_prog_run_report/report/index.html