### PR TITLE
Allow to_cross to work on DataArrays with scalar coordinates

### DIFF
--- a/external/vcm/tests/test_cubedsphere.py
+++ b/external/vcm/tests/test_cubedsphere.py
@@ -841,3 +841,15 @@ def test_to_cross(transpose, tile_dim, x_dim, y_dim):
     # manually hardcode the hash since it is shared across all parameterize
     # statements
     assert joblib.hash(one_tile.values) == "04eddd324d0f3150a02499c788ec675d"
+
+
+def test_to_cross_with_scalar_coordinates():
+    arr = xr.DataArray(
+        np.arange(2 * 2 * 6).reshape((6, 2, 2)),
+        dims=("tile", "y", "x"),
+        coords={"time": 1},
+    )
+    result = to_cross(arr, tile="tile", x="x", y="y")
+    expected_time = xr.DataArray(1, coords={"time": 1}, name="time")
+    assert "time" in result.coords
+    xr.testing.assert_identical(result.time, expected_time)

--- a/external/vcm/vcm/cubedsphere/cross.py
+++ b/external/vcm/vcm/cubedsphere/cross.py
@@ -54,6 +54,8 @@ def _rotate_data_array(data, src, dest, dims=None):
     for key in data.coords:
         if set(data[key].dims) >= set(dims):
             coords[key] = rotate(data[key].variable, src, dest, dims)
+        else:
+            coords[key] = data[key]
     return xr.DataArray(variable, coords=coords)
 
 


### PR DESCRIPTION
I've been using this a fair amount in taking at look at output from recent experiments.  One thing I've noticed is that `vcm.cubedsphere.to_cross` currently fails if the input DataArray contains a scalar coordinate (this often happens if I select a single time slice).  This PR makes a simple fix such that scalar coordinates are propagated along with the rotated DataArray in `_rotate_data_array`.

See the details for a minimal example:
<details>
<p>

```
>>> import xarray as xr; from vcm.cubedsphere import to_cross
>>> da = xr.DataArray(
    np.arange(2 * 2 * 6).reshape((6, 2, 2)),
    dims=("tile", "y", "x"),
    coords={"time": 1},
)
>>> to_cross(da, tile="tile", x="x", y="y")

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-9-67b29d3c1097> in <module>
----> 1 to_cross(arr, tile="tile", x="x", y="y")

~/fv3net/external/vcm/vcm/cubedsphere/cross.py in to_cross(data, tile, x, y)
     94             row.append(arr)
     95         tiles.append(row)
---> 96     return xr.combine_nested(tiles, concat_dim=dims)

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/combine.py in combine_nested(datasets, concat_dim, compat, data_vars, coords, fill_value, join, combine_attrs)
    534         fill_value=fill_value,
    535         join=join,
--> 536         combine_attrs=combine_attrs,
    537     )
    538 

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/combine.py in _nested_combine(datasets, concat_dims, compat, data_vars, coords, ids, fill_value, join, combine_attrs)
    330         fill_value=fill_value,
    331         join=join,
--> 332         combine_attrs=combine_attrs,
    333     )
    334     return combined

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/combine.py in _combine_nd(combined_ids, concat_dims, data_vars, coords, compat, fill_value, join, combine_attrs)
    204             fill_value=fill_value,
    205             join=join,
--> 206             combine_attrs=combine_attrs,
    207         )
    208     (combined_ds,) = combined_ids.values()

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/combine.py in _combine_all_along_first_dim(combined_ids, dim, data_vars, coords, compat, fill_value, join, combine_attrs)
    233         datasets = combined_ids.values()
    234         new_combined_ids[new_id] = _combine_1d(
--> 235             datasets, dim, compat, data_vars, coords, fill_value, join, combine_attrs
    236         )
    237     return new_combined_ids

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/combine.py in _combine_1d(datasets, concat_dim, compat, data_vars, coords, fill_value, join, combine_attrs)
    263                 fill_value=fill_value,
    264                 join=join,
--> 265                 combine_attrs=combine_attrs,
    266             )
    267         except ValueError as err:

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/concat.py in concat(objs, dim, data_vars, coords, compat, positions, fill_value, join, combine_attrs)
    190         )
    191     return f(
--> 192         objs, dim, data_vars, coords, compat, positions, fill_value, join, combine_attrs
    193     )
    194 

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/concat.py in _dataarray_concat(arrays, dim, data_vars, coords, compat, positions, fill_value, join, combine_attrs)
    525         fill_value=fill_value,
    526         join=join,
--> 527         combine_attrs="drop",
    528     )
    529 

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/concat.py in _dataset_concat(datasets, dim, data_vars, coords, compat, positions, fill_value, join, combine_attrs)
    404     # determine which variables to concatentate
    405     concat_over, equals, concat_dim_lengths = _calc_concat_over(
--> 406         datasets, dim, dim_names, data_vars, coords, compat
    407     )
    408 

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/concat.py in _calc_concat_over(datasets, dim, dim_names, data_vars, coords, compat)
    330 
    331     process_subset_opt(data_vars, "data_vars")
--> 332     process_subset_opt(coords, "coords")
    333     return concat_over, equals, concat_dim_lengths
    334 

~/miniconda3/envs/fv3net/lib/python3.7/site-packages/xarray/core/concat.py in process_subset_opt(opt, subset)
    265                         elif len(variables) != len(datasets) and opt == "different":
    266                             raise ValueError(
--> 267                                 f"{k!r} not present in all datasets and coords='different'. "
    268                                 f"Either add {k!r} to datasets where it is missing or "
    269                                 "specify coords='minimal'."

ValueError: 'time' not present in all datasets and coords='different'. Either add 'time' to datasets where it is missing or specify coords='minimal'.
```
</p>
</details>

- [ ] Tests added

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).

