### PR TITLE
Offline diags: Separate page for model sensitivity figures

### DIFF
--- a/workflows/offline_ml_diags/offline_ml_diags/_helpers.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/_helpers.py
@@ -9,7 +9,6 @@ import warnings
 import xarray as xr
 import yaml
 
-import report
 from vcm import safe
 from vcm.cloud import gsutil
 from vcm.catalog import catalog
@@ -137,26 +136,6 @@ def load_grid_info(res: str = "c48"):
     land_sea_mask = catalog[f"landseamask/{res}"].read()
     grid_info = xr.merge([grid, wind_rotation, land_sea_mask])
     return safe.get_variables(grid_info, GRID_INFO_VARS).drop("tile")
-
-
-def write_report(
-    output_dir: str,
-    title: str,
-    sections: Mapping[str, Sequence[str]],
-    metadata: report.Metadata = None,
-    report_metrics: report.Metrics = None,
-    html_header: str = None,
-):
-    filename = "index.html"
-    html_report = report.create_html(
-        sections,
-        title,
-        metadata=metadata,
-        metrics=report_metrics,
-        html_header=html_header,
-    )
-    with open(os.path.join(output_dir, filename), "w") as f:
-        f.write(html_report)
 
 
 def open_diagnostics_outputs(

--- a/workflows/offline_ml_diags/offline_ml_diags/compute_diags.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/compute_diags.py
@@ -415,9 +415,12 @@ def main(args):
     ds_diagnostics["time"] = times_used
     ds_diurnal["time"] = times_used
 
-    # save jacobian
+    # save model senstivity figures: jacobian (TODO: RF feature sensitivity)
     try:
-        plot_jacobian(model, args.output_path)  # type: ignore
+        plot_jacobian(
+            model,
+            os.path.join(args.output_path, "model_sensitivity_figures"),  # type: ignore
+        )
     except AttributeError:
         pass
 

--- a/workflows/offline_ml_diags/offline_ml_diags/create_report.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/create_report.py
@@ -37,6 +37,8 @@ NC_FILE_DIURNAL = "diurnal_cycle.nc"
 NC_FILE_TRANSECT = "transect_lon0.nc"
 JSON_FILE_METRICS = "scalar_metrics.json"
 
+MODEL_SENSITIVITY_HTML = "model_sensitivity.html"
+
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(
     logging.Formatter("%(name)s %(asctime)s: %(module)s/L%(lineno)d %(message)s")
@@ -85,11 +87,169 @@ def _create_arg_parser() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def render_model_sensitivity(figures_dir, output_dir) -> str:
+    report_sections: MutableMapping[str, Sequence[str]] = {}
+
+    for png in copy_pngs_to_report(figures_dir, output_dir):
+        report_sections[png] = [png]
+
+    return report.create_html(
+        sections=report_sections, title="Model sensitivity to inputs",
+    )
+
+
+def render_index(metrics, ds_diags, ds_diurnal, ds_transect, output_dir) -> str:
+    report_sections: MutableMapping[str, Sequence[str]] = {}
+
+    # Links
+    report_sections["Links"] = [
+        report.Link("Model input sensitivity", MODEL_SENSITIVITY_HTML),
+    ]
+
+    # histogram of timesteps used for testing
+    try:
+        timesteps = ds_diurnal["time"]
+    except KeyError:
+        pass
+    else:
+        timesteps = np.vectorize(vcm.cast_to_datetime)(timesteps)
+        fig = fv3viz.plot_daily_and_hourly_hist(timesteps)
+        fig.set_size_inches(10, 3)
+        report.insert_report_figure(
+            report_sections,
+            fig,
+            filename="timesteps_used.png",
+            section_name="Timesteps used for testing",
+            output_dir=output_dir,
+        )
+
+    # Zonal average of vertical profiles for bias and R2
+    zonal_avg_pressure_level_metrics = [
+        var
+        for var in ds_diags.data_vars
+        if var.startswith("zonal_avg_pressure")
+        and var.endswith("predict_vs_target")
+        and ("r2" in var or "bias" in var)
+    ]
+    for var in sorted(zonal_avg_pressure_level_metrics):
+        vmin, vmax = (0, 1) if "r2" in var.lower() else (None, None)
+        fig = diagplot.plot_zonal_average(
+            data=ds_diags[var],
+            title=tidy_title(var),
+            plot_kwargs={"vmin": vmin, "vmax": vmax},
+        )
+        report.insert_report_figure(
+            report_sections,
+            fig,
+            filename=f"zonal_avg_pressure_{var}.png",
+            section_name="Zonal averaged pressure level metrics",
+            output_dir=output_dir,
+        )
+
+    # vertical profiles of bias and R2
+    pressure_level_metrics = [
+        var
+        for var in ds_diags.data_vars
+        if var.startswith("pressure_level") and var.endswith("predict_vs_target")
+    ]
+    for var in sorted(pressure_level_metrics):
+        ylim = (0, 1) if "r2" in var.lower() else None
+        fig = diagplot._plot_generic_data_array(
+            ds_diags[var], xlabel="pressure [Pa]", ylim=ylim, title=tidy_title(var)
+        )
+        report.insert_report_figure(
+            report_sections,
+            fig,
+            filename=f"{var}.png",
+            section_name="Pressure level metrics",
+            output_dir=output_dir,
+        )
+
+    # time averaged quantity vertical profiles over land/sea, pos/neg net precip
+    profiles = [
+        var
+        for var in ds_diags.data_vars
+        if ("Q1" in var or "Q2" in var) and is_3d(ds_diags[var])
+    ]
+    for var in sorted(profiles):
+        fig = diagplot.plot_profile_var(
+            ds_diags, var, derivation_dim=DERIVATION_DIM, domain_dim=DOMAIN_DIM,
+        )
+        report.insert_report_figure(
+            report_sections,
+            fig,
+            filename=f"{var}.png",
+            section_name="Vertical profiles of predicted variables",
+            output_dir=output_dir,
+        )
+
+    column_integrated_metrics = column_integrated_metric_names(metrics)
+
+    # time averaged column integrated quantity maps
+    for var in column_integrated_metrics:
+        fig = diagplot.plot_column_integrated_var(
+            ds_diags, var, derivation_plot_coords=ds_diags[DERIVATION_DIM].values,
+        )
+        report.insert_report_figure(
+            report_sections,
+            fig,
+            filename=f"{var}.png",
+            section_name="Time averaged maps",
+            output_dir=output_dir,
+        )
+
+    # 2d quantity diurnal cycles
+    for var in ds_diurnal:
+        fig = diagplot.plot_diurnal_cycles(
+            ds_diurnal,
+            var=var,
+            derivation_plot_coords=ds_diurnal[DERIVATION_DIM].values,
+        )
+        report.insert_report_figure(
+            report_sections,
+            fig,
+            filename=f"{var}.png",
+            section_name="Diurnal cycles of column integrated quantities",
+            output_dir=output_dir,
+        )
+
+    # transect of predicted fields at lon=0
+    if len(ds_transect) > 0:
+        transect_time = ds_transect.time.item()
+        for var in sorted(ds_transect.data_vars):
+            fig = plot_transect(ds_transect[var])
+            report.insert_report_figure(
+                report_sections,
+                fig,
+                filename=f"transect_lon0_{var}.png",
+                section_name=f"Transect snapshot at lon=0 deg, {transect_time}",
+                output_dir=output_dir,
+            )
+
+    # scalar metrics for RMSE and bias
+    metrics_formatted = []
+    metrics = insert_scalar_metrics_r2(metrics, column_integrated_metrics)
+    for var in sorted(column_integrated_metrics):
+        values = {
+            "r2": get_metric_string(metrics, "r2", var),
+            "bias": " ".join(
+                [get_metric_string(metrics, "bias", var), units_from_name(var)]
+            ),
+        }
+        metrics_formatted.append((var.replace("_", " "), values))
+
+    return report.create_html(
+        sections=report_sections,
+        title="ML offline diagnostics",
+        metadata=config,
+        metrics=dict(metrics_formatted),
+    )
+
+
 if __name__ == "__main__":
 
     logger.info("Starting create report routine.")
     args = _create_arg_parser()
-
     temp_output_dir = tempfile.TemporaryDirectory()
     atexit.register(_cleanup_temp_dir, temp_output_dir)
 
@@ -120,153 +280,18 @@ if __name__ == "__main__":
     if args.commit_sha:
         config["commit"] = args.commit_sha
 
-    report_sections: MutableMapping[str, Sequence[str]] = {}
-
-    # Links
-
-    # histogram of timesteps used for testing
-    try:
-        timesteps = ds_diurnal["time"]
-    except KeyError:
-        pass
-    else:
-        timesteps = np.vectorize(vcm.cast_to_datetime)(timesteps)
-        fig = fv3viz.plot_daily_and_hourly_hist(timesteps)
-        fig.set_size_inches(10, 3)
-        report.insert_report_figure(
-            report_sections,
-            fig,
-            filename="timesteps_used.png",
-            section_name="Timesteps used for testing",
-            output_dir=temp_output_dir.name,
-        )
-
-    # Zonal average of vertical profiles for bias and R2
-    zonal_avg_pressure_level_metrics = [
-        var
-        for var in ds_diags.data_vars
-        if var.startswith("zonal_avg_pressure")
-        and var.endswith("predict_vs_target")
-        and ("r2" in var or "bias" in var)
-    ]
-    for var in sorted(zonal_avg_pressure_level_metrics):
-        vmin, vmax = (0, 1) if "r2" in var.lower() else (None, None)
-        fig = diagplot.plot_zonal_average(
-            data=ds_diags[var],
-            title=tidy_title(var),
-            plot_kwargs={"vmin": vmin, "vmax": vmax},
-        )
-        report.insert_report_figure(
-            report_sections,
-            fig,
-            filename=f"zonal_avg_pressure_{var}.png",
-            section_name="Zonal averaged pressure level metrics",
-            output_dir=temp_output_dir.name,
-        )
-
-    # vertical profiles of bias and R2
-    pressure_level_metrics = [
-        var
-        for var in ds_diags.data_vars
-        if var.startswith("pressure_level") and var.endswith("predict_vs_target")
-    ]
-    for var in sorted(pressure_level_metrics):
-        ylim = (0, 1) if "r2" in var.lower() else None
-        fig = diagplot._plot_generic_data_array(
-            ds_diags[var], xlabel="pressure [Pa]", ylim=ylim, title=tidy_title(var)
-        )
-        report.insert_report_figure(
-            report_sections,
-            fig,
-            filename=f"{var}.png",
-            section_name="Pressure level metrics",
-            output_dir=temp_output_dir.name,
-        )
-
-    # time averaged quantity vertical profiles over land/sea, pos/neg net precip
-    profiles = [
-        var
-        for var in ds_diags.data_vars
-        if ("Q1" in var or "Q2" in var) and is_3d(ds_diags[var])
-    ]
-    for var in sorted(profiles):
-        fig = diagplot.plot_profile_var(
-            ds_diags, var, derivation_dim=DERIVATION_DIM, domain_dim=DOMAIN_DIM,
-        )
-        report.insert_report_figure(
-            report_sections,
-            fig,
-            filename=f"{var}.png",
-            section_name="Vertical profiles of predicted variables",
-            output_dir=temp_output_dir.name,
-        )
-
-    column_integrated_metrics = column_integrated_metric_names(metrics)
-
-    # time averaged column integrated quantity maps
-    for var in column_integrated_metrics:
-        fig = diagplot.plot_column_integrated_var(
-            ds_diags, var, derivation_plot_coords=ds_diags[DERIVATION_DIM].values,
-        )
-        report.insert_report_figure(
-            report_sections,
-            fig,
-            filename=f"{var}.png",
-            section_name="Time averaged maps",
-            output_dir=temp_output_dir.name,
-        )
-
-    # 2d quantity diurnal cycles
-    for var in ds_diurnal:
-        fig = diagplot.plot_diurnal_cycles(
-            ds_diurnal,
-            var=var,
-            derivation_plot_coords=ds_diurnal[DERIVATION_DIM].values,
-        )
-        report.insert_report_figure(
-            report_sections,
-            fig,
-            filename=f"{var}.png",
-            section_name="Diurnal cycles of column integrated quantities",
-            output_dir=temp_output_dir.name,
-        )
-
-    # transect of predicted fields at lon=0
-    if len(ds_transect) > 0:
-        transect_time = ds_transect.time.item()
-        for var in sorted(ds_transect.data_vars):
-            fig = plot_transect(ds_transect[var])
-            report.insert_report_figure(
-                report_sections,
-                fig,
-                filename=f"transect_lon0_{var}.png",
-                section_name=f"Transect snapshot at lon=0 deg, {transect_time}",
-                output_dir=temp_output_dir.name,
-            )
-
-    # scalar metrics for RMSE and bias
-    metrics_formatted = []
-    metrics = insert_scalar_metrics_r2(metrics, column_integrated_metrics)
-    for var in sorted(column_integrated_metrics):
-        values = {
-            "r2": get_metric_string(metrics, "r2", var),
-            "bias": " ".join(
-                [get_metric_string(metrics, "bias", var), units_from_name(var)]
-            ),
-        }
-        metrics_formatted.append((var.replace("_", " "), values))
-
-    for png in copy_pngs_to_report(args.input_path, temp_output_dir.name):
-        report_sections[png] = [png]
-
-    html_report = report.create_html(
-        sections=report_sections,
-        title="ML offline diagnostics",
-        metadata=config,
-        metrics=dict(metrics_formatted),
+    html_index = render_index(
+        metrics, ds_diags, ds_diurnal, ds_transect, output_dir=temp_output_dir.name
     )
     with open(os.path.join(temp_output_dir.name, "index.html"), "w") as f:
-        f.write(html_report)
+        f.write(html_index)
+
+    html_model_sensitivity = render_model_sensitivity(
+        os.path.join(args.input_path, "model_sensitivity_figures"),
+        output_dir=temp_output_dir.name,
+    )
+    with open(os.path.join(temp_output_dir.name, MODEL_SENSITIVITY_HTML), "w") as f:
+        f.write(html_model_sensitivity)
 
     copy_outputs(temp_output_dir.name, args.output_path)
     logger.info(f"Save report to {args.output_path}")


### PR DESCRIPTION
This PR moves the section containing the Jacobian figures (if applicable) to a separate page linked from the main report page. A future PR will add figures for feature importance if the model in the report is a RF.

There is a minor change to how the model sensitivity figures are saved in the `compute_diags` step; instead of being saved in the top level of the output directory they go into a subdir. This is so that if future pages are added to the report they can use the same pattern of using `copy_pngs_to_report(figures_dir, output)` to put the relevant figures on the page.

Example: https://storage.googleapis.com/vcm-ml-public/annak/2021-05-20-offline-report-add-pg/index.html
