### PR TITLE
Remove output path from keras fit logic

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -280,7 +280,7 @@ class PackedKerasModel(Estimator):
             self.train_history["loss"].append(loss_over_batches)
             self.train_history["val_loss"].append(val_loss_over_batches)
             if self._checkpoint_path:
-                self.dump(os.path.join(self._checkpoint_path, f"epoch_{i_epoch}"))
+                self.dump(os.path.join(self._checkpoint_path.name, f"epoch_{i_epoch}"))
                 logger.info(
                     f"Saved model checkpoint after epoch {i_epoch} "
                     f"to {self._checkpoint_path}"
@@ -304,7 +304,8 @@ class PackedKerasModel(Estimator):
                 self.model.save(model_filename)
             if self._checkpoint_path is not None:
                 shutil.copytree(
-                    self._checkpoint_path, os.path.join(path, KERAS_CHECKPOINT_PATH)
+                    self._checkpoint_path.name,
+                    os.path.join(path, KERAS_CHECKPOINT_PATH),
                 )
             with open(os.path.join(path, self._X_PACKER_FILENAME), "w") as f:
                 self.X_packer.dump(f)

--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -279,8 +279,6 @@ class PackedKerasModel(Estimator):
                 val_loss_over_batches += history.history.get("val_loss", [np.nan])
             self.train_history["loss"].append(loss_over_batches)
             self.train_history["val_loss"].append(val_loss_over_batches)
-            if self._save_model_checkpoints:
-                self._checkpoints.append(copy.deepcopy(self))
             if self._checkpoint_path:
                 self.dump(os.path.join(self._checkpoint_path, f"epoch_{i_epoch}"))
                 logger.info(

--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -7,6 +7,8 @@ import copy
 import json
 import tensorflow as tf
 import tensorflow_addons as tfa
+import tempfile
+import shutil
 
 from ..._shared.packer import ArrayPacker, unpack_matrix
 from ..._shared.predictor import Estimator
@@ -23,6 +25,7 @@ import yaml
 logger = logging.getLogger(__file__)
 
 MODEL_DIRECTORY = "model_data"
+KERAS_CHECKPOINT_PATH = "model_checkpoints"
 
 # Description of the training loss progression over epochs
 # Outer array indexes epoch, inner array indexes batch (if applicable)
@@ -60,7 +63,7 @@ class PackedKerasModel(Estimator):
         optimizer: tf.keras.optimizers.Optimizer = tf.keras.optimizers.Adam,
         kernel_regularizer: Optional[tf.keras.regularizers.Regularizer] = None,
         loss: Literal["mse", "mae"] = "mse",
-        checkpoint_path: Optional[str] = None,
+        save_model_checkpoints: bool = False,
         fit_kwargs: Optional[dict] = None,
     ):
         """Initialize the model.
@@ -86,6 +89,8 @@ class PackedKerasModel(Estimator):
             optimizer: algorithm to be used in gradient descent, must subclass
                 tf.keras.optimizers.Optimizer; defaults to tf.keras.optimizers.Adam
             loss: loss function to use. Defaults to mean squared error.
+            save_model_checkpoints: if True, save one model per epoch when
+                dumping, under a 'model_checkpoints' subdirectory
             fit_kwargs: other keyword arguments to be passed to the underlying
                 tf.keras.Model.fit() method
         """
@@ -108,7 +113,13 @@ class PackedKerasModel(Estimator):
         self._optimizer = optimizer
         self._loss = loss
         self._kernel_regularizer = kernel_regularizer
-        self._checkpoint_path = checkpoint_path
+        self._save_model_checkpoints = save_model_checkpoints
+        if save_model_checkpoints:
+            self._checkpoint_path: Optional[
+                tempfile.TemporaryDirectory
+            ] = tempfile.TemporaryDirectory()
+        else:
+            self._checkpoint_path = None
         self._fit_kwargs = fit_kwargs or {}
 
     @property
@@ -268,6 +279,8 @@ class PackedKerasModel(Estimator):
                 val_loss_over_batches += history.history.get("val_loss", [np.nan])
             self.train_history["loss"].append(loss_over_batches)
             self.train_history["val_loss"].append(val_loss_over_batches)
+            if self._save_model_checkpoints:
+                self._checkpoints.append(copy.deepcopy(self))
             if self._checkpoint_path:
                 self.dump(os.path.join(self._checkpoint_path, f"epoch_{i_epoch}"))
                 logger.info(
@@ -291,6 +304,10 @@ class PackedKerasModel(Estimator):
             if self._model is not None:
                 model_filename = os.path.join(path, self._MODEL_FILENAME)
                 self.model.save(model_filename)
+            if self._checkpoint_path is not None:
+                shutil.copytree(
+                    self._checkpoint_path, os.path.join(path, KERAS_CHECKPOINT_PATH)
+                )
             with open(os.path.join(path, self._X_PACKER_FILENAME), "w") as f:
                 self.X_packer.dump(f)
             with open(os.path.join(path, self._Y_PACKER_FILENAME), "w") as f:
@@ -414,7 +431,7 @@ class DenseModel(PackedKerasModel):
         gaussian_noise: float = 0.0,
         loss: Literal["mse", "mae"] = "mse",
         spectral_normalization: bool = False,
-        checkpoint_path: Optional[str] = None,
+        save_model_checkpoints: bool = False,
         fit_kwargs: Optional[dict] = None,
     ):
         """Initialize the DenseModel.
@@ -446,6 +463,8 @@ class DenseModel(PackedKerasModel):
             gaussian_noise: how much gaussian noise to add before each Dense layer,
                 apart from the output layer
             loss: loss function to use. Defaults to mean squared error.
+            save_model_checkpoints: if True, save one model per epoch when
+                dumping, under a 'model_checkpoints' subdirectory
             fit_kwargs: other keyword arguments to be passed to the underlying
                 tf.keras.Model.fit() method
         """
@@ -463,7 +482,7 @@ class DenseModel(PackedKerasModel):
             optimizer=optimizer,
             kernel_regularizer=kernel_regularizer,
             loss=loss,
-            checkpoint_path=checkpoint_path,
+            save_model_checkpoints=save_model_checkpoints,
             fit_kwargs=fit_kwargs,
         )
 

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -21,9 +21,6 @@ import fv3fit.sklearn
 import fv3fit
 
 
-KERAS_CHECKPOINT_PATH = "model_checkpoints"
-
-
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -68,11 +65,6 @@ def _get_model(config: fv3fit.TrainingConfig) -> Estimator:
             **config.hyperparameters,
         )
     elif isinstance(config, fv3fit.KerasTrainingConfig):
-        checkpoint_path = (
-            os.path.join(args.output_data_path, KERAS_CHECKPOINT_PATH)
-            if config.save_model_checkpoints
-            else None
-        )
         return fv3fit.keras.get_model(
             model_type=config.model_type,
             sample_dim_name=loaders.SAMPLE_DIM_NAME,
@@ -80,7 +72,7 @@ def _get_model(config: fv3fit.TrainingConfig) -> Estimator:
             output_variables=config.output_variables,
             optimizer=get_optimizer(config.hyperparameters),
             kernel_regularizer=get_regularizer(config.hyperparameters),
-            checkpoint_path=checkpoint_path,
+            save_model_checkpoints=config.save_model_checkpoints,
             **config.hyperparameters,
         )
     else:

--- a/external/fv3fit/tests/training/test_cli.py
+++ b/external/fv3fit/tests/training/test_cli.py
@@ -18,6 +18,15 @@ import subprocess
             },
         ),
         dict(
+            model_type="DenseModel",
+            hyperparameters={
+                "width": 4,
+                "depth": 3,
+                "fit_kwargs": {"batch_size": 100, "validation_samples": 384},
+            },
+            save_model_checkpoints=True,
+        ),
+        dict(
             model_type="sklearn_random_forest",
             hyperparameters={"max_depth": 4, "n_estimators": 2},
         ),


### PR DESCRIPTION
Currently, keras' fit routine is told where to dump checkpoint files. This makes it impossible to define a fit API based on a yaml configuration, because the output directory is a command-line argument.

This PR refactors keras's fit routine so checkpoints are only saved to the output directory when `model.dump` is called.

Significant internal changes:
- When checkpoint saving is enabled for keras fitting, it now saves the checkpoints to a temporary directory which gets copied to the output directory when the model dump routine is called.

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
