### PR TITLE
decouple offline_ml_diags tests from fv3fit, add new tests

### DIFF
--- a/workflows/offline_ml_diags/tests/test__ml_prediction.py
+++ b/workflows/offline_ml_diags/tests/test__ml_prediction.py
@@ -9,17 +9,13 @@ from offline_ml_diags._mapper import (
     DERIVATION_DIM,
 )
 
-from sklearn.dummy import DummyRegressor
-
-from fv3fit.keras import DummyModel
-from fv3fit.sklearn._random_forest import SklearnWrapper
-from vcm import safe
+import fv3fit
 
 
 class MockBaseMapper:
-    def __init__(self, ds_template):
+    def __init__(self, ds_template, n_keys=4):
         self._ds_template = ds_template
-        self._keys = [f"2020050{i+1}.000000" for i in range(4)]
+        self._keys = [f"2020050{i+1}.000000" for i in range(n_keys)]
 
     def __getitem__(self, key: str) -> xr.Dataset:
         ds = self._ds_template
@@ -35,97 +31,86 @@ class MockBaseMapper:
         return len(self.keys())
 
 
-@pytest.fixture
-def gridded_dataset():
-    zdim, ydim, xdim = 2, 10, 10
-    coords = {"z": range(zdim), "y": range(ydim), "x": range(xdim), "initial_time": [0]}
+def get_gridded_dataset(seed=0):
+    random = np.random.RandomState(seed=seed)
+    nz, ny, nx = 2, 10, 10
+    coords = {"z": range(nz), "y": range(ny), "x": range(nx)}
     # unique values for ease of set comparison in test
-    var = xr.DataArray(
-        [
-            [
-                [[(100 * z) + (10 * y) + x for x in range(xdim)] for y in range(ydim)]
-                for z in range(zdim)
-            ]
-        ],
-        dims=["initial_time", "z", "y", "x"],
-        coords=coords,
-    )
+    var = xr.DataArray(random.randn(nz, ny, nx), dims=["z", "y", "x"], coords=coords,)
     ds = xr.Dataset(
         dict(
-            **{f"feature{i}": (i + 1) * var for i in range(5)},
-            **{f"pred{i}": (i + 1) * var for i in range(5)},
+            **{f"feature{i}": (i + 1) + var for i in range(5)},
+            **{f"pred{i}": -(i + 1) - var for i in range(5)},
         )
     )
     return ds
 
 
 @pytest.fixture
-def base_mapper(gridded_dataset):
-    return MockBaseMapper(gridded_dataset)
-
-
-def mock_predict_function(sizes):
-    return xr.DataArray(np.zeros(list(sizes.values())), dims=[dim for dim in sizes])
-
-
-def get_mock_sklearn_model(input_variables, output_variables, ds):
-
-    dummy = DummyRegressor(strategy="mean")
-    model_wrapper = SklearnWrapper("sample", input_variables, output_variables, dummy)
-    ds_stacked = safe.stack_once(
-        ds, "sample", [dim for dim in ds.dims if dim != "z"]
-    ).transpose("sample", "z")
-    model_wrapper.fit([ds_stacked * 0])
-    return model_wrapper
-
-
-def get_mock_keras_model(input_variables, output_variables, ds):
-
-    model = DummyModel("sample", input_variables, output_variables)
-
-    ds_stacked = [
-        safe.stack_once(ds, "sample", [dim for dim in ds.dims if dim != "z"]).transpose(
-            "sample", "z"
-        )
-    ]
-
-    model.fit(ds_stacked)
-
-    return model
+def base_mapper():
+    return MockBaseMapper(get_gridded_dataset(seed=0))
 
 
 @pytest.fixture
-def mock_model(request, gridded_dataset):
-    model_type, input_variables, output_variables = request.param
-    if model_type == "keras":
-        return get_mock_keras_model(input_variables, output_variables, gridded_dataset)
-    elif model_type == "sklearn":
-        return get_mock_sklearn_model(
-            input_variables, output_variables, gridded_dataset
+def input_variables(request):
+    return request.param
+
+
+@pytest.fixture
+def output_variables(request):
+    return request.param
+
+
+class MockPredictor(fv3fit.Predictor):
+    """
+    An object that returns a constant dataset for predictions.
+    """
+
+    def __init__(self, input_variables, output_variables, output_ds: xr.Dataset):
+        self.input_variables = input_variables
+        self.output_variables = output_variables
+        non_predicted_names = set(output_ds.data_vars.keys()).difference(
+            output_variables
         )
-    else:
-        raise ValueError("Invalid model type")
+        self.output_ds = output_ds.drop(labels=non_predicted_names)
+        self.call_datasets = []
+
+    def predict(self, X: xr.Dataset):
+        raise NotImplementedError()
+
+    def predict_columnwise(self, X: xr.Dataset, *args, **kwargs) -> xr.Dataset:
+        self.call_datasets.append(X)
+        return self.output_ds
+
+    def dump(self, path):
+        raise NotImplementedError()
+
+    @classmethod
+    def load(cls, path):
+        raise NotImplementedError()
+
+
+def get_mock_model(input_variables, output_variables):
+    # must use different random seed than for base_mapper fixture
+    output_ds = get_gridded_dataset(seed=1)
+    return MockPredictor(input_variables, output_variables, output_ds=output_ds)
 
 
 @pytest.mark.parametrize(
-    "mock_model",
+    "input_variables, output_variables",
     [
-        pytest.param(("keras", ["feature0", "feature1"], ["pred0"]), id="keras_2_1"),
-        pytest.param(
-            ("keras", ["feature0", "feature1"], ["pred0", "pred1"]), id="keras_2_2"
-        ),
-        pytest.param(("keras", ["feature0"], ["pred0", "pred1"]), id="keras_1_2"),
-        pytest.param(
-            ("sklearn", ["feature0", "feature1"], ["pred0"]), id="sklearn_2_1"
-        ),
-        pytest.param(
-            ("sklearn", ["feature0", "feature1"], ["pred0", "pred1"]), id="sklearn_2_2"
-        ),
-        pytest.param(("sklearn", ["feature0"], ["pred0", "pred1"]), id="sklearn_1_2"),
+        pytest.param(["feature0", "feature1"], ["pred0"], id="keras_2_1"),
+        pytest.param(["feature0", "feature1"], ["pred0", "pred1"], id="keras_2_2"),
+        pytest.param(["feature0"], ["pred0", "pred1"], id="keras_1_2"),
+        pytest.param(["feature0", "feature1"], ["pred0"], id="sklearn_2_1"),
+        pytest.param(["feature0", "feature1"], ["pred0", "pred1"], id="sklearn_2_2"),
+        pytest.param(["feature0"], ["pred0", "pred1"], id="sklearn_1_2"),
     ],
-    indirect=True,
 )
-def test_ml_predict_mapper_insert_prediction(mock_model, base_mapper, gridded_dataset):
+def test_ml_predict_mapper_insert_prediction(
+    input_variables, output_variables, base_mapper
+):
+    mock_model = get_mock_model(input_variables, output_variables)
     variables = mock_model.output_variables + mock_model.input_variables
     mapper = PredictionMapper(
         base_mapper, mock_model, variables, z_dim="z", grid=xr.Dataset()
@@ -140,40 +125,95 @@ def test_ml_predict_mapper_insert_prediction(mock_model, base_mapper, gridded_da
 
 
 @pytest.mark.parametrize(
-    "mock_model",
+    "input_variables, output_variables",
     [
-        pytest.param(("keras", ["feature0", "feature1"], ["pred0"]), id="keras_2_1"),
-        pytest.param(
-            ("keras", ["feature0", "feature1"], ["pred0", "pred1"]), id="keras_2_2"
-        ),
-        pytest.param(
-            ("sklearn", ["feature0", "feature1"], ["pred0"]), id="sklearn_2_1"
-        ),
-        pytest.param(
-            ("sklearn", ["feature0", "feature1"], ["pred0", "pred1"]), id="sklearn_2_2"
-        ),
+        pytest.param(["feature0", "feature1"], ["pred0"], id="keras_2_1"),
+        pytest.param(["feature0", "feature1"], ["pred0", "pred1"], id="keras_2_2"),
+        pytest.param(["feature0", "feature1"], ["pred0"], id="sklearn_2_1"),
+        pytest.param(["feature0", "feature1"], ["pred0", "pred1"], id="sklearn_2_2"),
     ],
-    indirect=True,
 )
-def test_ml_predict_mapper(mock_model, base_mapper, gridded_dataset):
+def test_ml_predict_mapper(input_variables, output_variables, base_mapper):
+    mock_model = get_mock_model(input_variables, output_variables)
     variables = mock_model.output_variables + mock_model.input_variables
-    mapper = PredictionMapper(
+    prediction_mapper = PredictionMapper(
         base_mapper, mock_model, variables, z_dim="z", grid=xr.Dataset()
     )
-    for key in mapper.keys():
-        mapper_output = mapper[key]
+    for key in prediction_mapper.keys():
+        prediction_output = prediction_mapper[key]
         for var in mock_model.output_variables:
             target = base_mapper[key][var]
             truth = (
-                mapper_output[var]
+                prediction_output[var]
                 .sel({DERIVATION_DIM: "target"})
                 .drop([DERIVATION_DIM, "time"])
             )
             prediction = (
-                mapper_output[var]
+                prediction_output[var]
                 .sel({DERIVATION_DIM: "predict"})
                 .drop([DERIVATION_DIM, "time"])
             )
             xr.testing.assert_allclose(truth, target)
-            # assume the model outputs 0.0
-            xr.testing.assert_allclose(prediction, target * 0.0)
+            xr.testing.assert_allclose(prediction, mock_model.output_ds[var])
+
+
+def test_prediction_mapper_inserts_grid_to_input(base_mapper):
+    input_variables, output_variables = ["feature0", "feature1"], ["pred0", "pred1"]
+    mock_model = get_mock_model(input_variables, output_variables)
+    grid_ds = xr.Dataset(
+        data_vars={
+            "grid_var": xr.DataArray(
+                np.random.randn(3, 4, 5), dims=["dim1", "dim2", "dim3"]
+            )
+        }
+    )
+    variables = (
+        mock_model.output_variables
+        + mock_model.input_variables
+        + list(grid_ds.data_vars.keys())
+    )
+    prediction_mapper = PredictionMapper(
+        base_mapper, mock_model, variables, z_dim="z", grid=grid_ds
+    )
+    # need to call using any arbitrary key
+    key = list(prediction_mapper.keys())[0]
+    prediction_mapper[key]
+    assert len(mock_model.call_datasets) == 1, "should be called only once"
+    passed_ds = mock_model.call_datasets[0]
+    for varname in grid_ds.data_vars:
+        xr.testing.assert_identical(grid_ds[varname], passed_ds[varname].drop("time"))
+
+
+def test_prediction_mapper_output_contains_input_value(base_mapper):
+    input_variables, output_variables = ["feature0", "feature1"], ["pred0"]
+    mock_model = get_mock_model(input_variables, output_variables)
+    variables = mock_model.output_variables + mock_model.input_variables + ["pred1"]
+    prediction_mapper = PredictionMapper(
+        base_mapper, mock_model, variables, z_dim="z", grid=xr.Dataset()
+    )
+    # need to call using any arbitrary key
+    key = list(prediction_mapper.keys())[0]
+    output = prediction_mapper[key]
+    assert "pred1" in output
+    xr.testing.assert_equal(output["pred1"].drop("time"), base_mapper[key]["pred1"])
+
+
+def test_prediction_mapper_output_contains_grid_value(base_mapper):
+    input_variables, output_variables = ["feature0", "feature1"], ["pred0"]
+    mock_model = get_mock_model(input_variables, output_variables)
+    grid_ds = xr.Dataset(
+        data_vars={
+            "grid_var": xr.DataArray(
+                np.random.randn(3, 4, 5), dims=["dim1", "dim2", "dim3"]
+            )
+        }
+    )
+    variables = mock_model.output_variables + mock_model.input_variables + ["grid_var"]
+    prediction_mapper = PredictionMapper(
+        base_mapper, mock_model, variables, z_dim="z", grid=grid_ds
+    )
+    # need to call using any arbitrary key
+    key = list(prediction_mapper.keys())[0]
+    output = prediction_mapper[key]
+    assert "grid_var" in output
+    xr.testing.assert_equal(output["grid_var"].drop("time"), grid_ds["grid_var"])


### PR DESCRIPTION
offline_ml_diags currently has tests for PredictionMapper that depend on implementation details of fv3fit. The tests also don't currently cover behaviors involving passing input or grid variables into the output dataset.

This PR adds tests for those behaviors, and decouples the existing tests from fv3fit using a mock predictor.

Refactored public API:
- renamed "wrapped_model" to "predictor" in PredictionMapper API
- removed unused "rename_vars" argument from PredictionMapper

Significant internal changes:
- offline_ml_diags tests no longer instantiate Keras or Sklearn predictors, instead using a mock predictor with a constant output dataset
- Added tests that PredictionMapper passes input and grid variables into output datasets when requested
- Use non-zero output values in offline_ml_diags tests when testing equality of PredictionMapper outputs to Predictor outputs

- [x] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
