### PR TITLE
Give create-run step in run-fv3gfs more memory

### DIFF
--- a/workflows/argo/run-fv3gfs.yaml
+++ b/workflows/argo/run-fv3gfs.yaml
@@ -21,8 +21,6 @@ spec:
           arguments:
             parameters:
             - {name: runURL, value: "{{inputs.parameters.output-url}}"}
-            - {name: cpu, value: "{{inputs.parameters.cpu}}"}
-            - {name: memory, value: "{{inputs.parameters.memory}}"}
             artifacts:
               - name: fv3config
                 from: "{{inputs.artifacts.fv3config}}"
@@ -84,7 +82,7 @@ spec:
       command: ["/bin/bash", "-c", "-x", "-e"]
       resources:
         limits:
-            memory: "250Mi"
+            memory: "500Mi"
             cpu: "500m"
       args:
       - |


### PR DESCRIPTION
End-to-end integration test has been failing on the `create-run` step, often with OOM. Try increasing memory limit. Also removes two unused parameters to the step.