### PR TITLE
Experiment/backport-nn-rectification

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -153,6 +153,9 @@ class DenseHyperparameters:
         spectral_normalization: whether to apply spectral normalization to hidden layers
         save_model_checkpoints: if True, save one model per epoch when
             dumping, under a 'model_checkpoints' subdirectory
+        nonnegative_outputs: if True, add a ReLU activation layer as the last layer
+            after output denormalization layer to ensure outputs are always >=0
+            Defaults to False.
         fit_kwargs: other keyword arguments to be passed to the underlying
             tf.keras.Model.fit() method
     """
@@ -169,6 +172,7 @@ class DenseHyperparameters:
     loss: str = "mse"
     spectral_normalization: bool = False
     save_model_checkpoints: bool = False
+    nonnegative_outputs: bool = False
 
     # TODO: remove fit_kwargs by fixing how validation data is passed
     fit_kwargs: Optional[dict] = None

--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -84,6 +84,7 @@ class DenseModel(Estimator):
         self._width = hyperparameters.width
         self._spectral_normalization = hyperparameters.spectral_normalization
         self._gaussian_noise = hyperparameters.gaussian_noise
+        self._nonnegative_outputs = hyperparameters.nonnegative_outputs
         super().__init__(sample_dim_name, input_variables, output_variables)
         self._model = None
         self.X_packer = ArrayPacker(
@@ -142,6 +143,8 @@ class DenseModel(Estimator):
             x = hidden_layer(x)
         x = tf.keras.layers.Dense(n_features_out)(x)
         outputs = self.y_scaler.denormalize_layer(x)
+        if self._nonnegative_outputs:
+            outputs = tf.keras.layers.Activation(tf.keras.activations.relu)(outputs)
         model = tf.keras.Model(inputs=inputs, outputs=outputs)
         model.compile(optimizer=self._optimizer, loss=self.loss)
         return model

--- a/external/fv3fit/tests/test_models.py
+++ b/external/fv3fit/tests/test_models.py
@@ -59,3 +59,18 @@ def test_fill_default(kwargs, arg, key, default, expected):
             _fill_default(kwargs, arg, key, default)
     else:
         assert _fill_default(kwargs, arg, key, default) == expected
+
+
+def test_nonnegative_model_outputs():
+    hyperparameters = DenseHyperparameters(nonnegative_outputs=True)
+    model = DenseModel("sample", ["input"], ["output"], hyperparameters,)
+    batch = xr.Dataset(
+        {
+            "input": (["sample"], np.arange(100)),
+            # even with negative targets, trained model should be nonnegative
+            "output": (["sample"], np.full((100,), -1e4)),
+        }
+    )
+    model.fit([batch])
+    prediction = model.predict(batch)
+    assert prediction.min() >= 0.0


### PR DESCRIPTION
* Add rectify_outputs to DenseModelHyperparameters: if True, adds a ReLu layer after denormalize in DenseModel. Defaults to False.

Short description of why the PR is needed and how it satisfies those requirements, in sentence form.

(Delete unused sections)
Added public API:
- symbol (e.g. `vcm.my_function`) or script and optional description of changes or why they are needed
- Can group multiple related symbols on a single bullet

Refactored public API:
- Bulleted list of removed or refactored symbols, such as changes to name, type, behavior, argument, etc. Be cautious about doing these and discuss with team more broadly.

Significant internal changes:
- Bulleted list of changes to non-public API

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [ ] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))

- [ ] Tests added

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
