### PR TITLE
enable pytest-xdist for fv3fit tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,6 +11,7 @@ altair==4.1.0
 anyio==2.2.0
 apache-beam==2.27.0
 appdirs==1.4.4
+appnope==0.1.2
 argcomplete==1.12.0
 argon2-cffi==20.1.0
 asciitree==0.3.3
@@ -44,7 +45,6 @@ colorcet==2.0.6
 commonmark==0.9.1
 conda-lock==0.4.1
 crcmod==1.7
-cryptography==3.4.7
 cycler==0.10.0
 dacite==1.6.0
 dask==2.22.0
@@ -56,6 +56,7 @@ docopt==0.6.2
 docrep==0.2.7
 docutils==0.16
 entrypoints==0.3
+execnet==1.9.0
 f90nml==1.1.2
 fastavro==1.3.0
 fasteners==0.15
@@ -109,7 +110,6 @@ ipython-genutils==0.2.0
 ipython==7.16.1
 ipywidgets==7.6.3
 jedi==0.18.0
-jeepney==0.6.0
 jinja2==2.11.2
 joblib==0.16.0
 json5==0.9.5
@@ -196,7 +196,9 @@ pylev==1.3.0
 pymongo==3.11.2
 pyparsing==2.4.7
 pyrsistent==0.14.11
+pytest-forked==1.3.0
 pytest-regtest==1.4.4
+pytest-xdist==2.3.0
 pytest==6.0.1
 python-dateutil==2.8.1
 pytz==2020.1
@@ -211,7 +213,6 @@ retrying==1.3.3
 rsa==4.6
 scikit-learn==0.22.1
 scipy==1.5.4
-secretstorage==3.3.1
 send2trash==1.5.0
 shellingham==1.3.2
 six==1.15.0
@@ -251,7 +252,6 @@ tzlocal==2.1
 urllib3==1.25.10
 validators==0.18.2
 virtualenv==20.0.33
-watchdog==2.1.2
 wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==0.57.0

--- a/external/fv3fit/tox.ini
+++ b/external/fv3fit/tox.ini
@@ -10,11 +10,12 @@ envlist = py37
 install_command = pip install -c ../../constraints.txt {opts} {packages}
 deps = 
     pytest
+    pytest-xdist
     ../vcm
     ../synth
     ../loaders
 commands =
-    pytest
+    pytest -n auto
 passenv = 
     GOOGLE_APPLICATION_CREDENTIALS 
     NIX_SSL_CERT_FILE

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -4,6 +4,7 @@ nc-time-axis
 bump2version
 yq
 pytest-regtest
+pytest-xdist
 recommonmark
 sphinx>=1.4
 sphinx-argparse


### PR DESCRIPTION
Fv3fit tests take a fair while to run, due to tests which train and serialize/load models. This PR enables pytest-xdist for fv3fit tests, which runs tests on multiple processors. This reduces test time on my machine from 2 minutes to 40 seconds.

Significant internal changes:
- fv3fit tests use pytest-xdist

Requirement changes:
- added pytest-xdist to pip-requirements.txt
- [x] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [x] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))

Resolves #<github issues> [JIRA-TAG]

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
