### PR TITLE
Add precipitation histogram to prognostic run report

### DIFF
--- a/external/report/report/__init__.py
+++ b/external/report/report/__init__.py
@@ -1,3 +1,10 @@
-from .create_report import create_html, insert_report_figure, Metrics, Metadata, Link
+from .create_report import (
+    create_html,
+    insert_report_figure,
+    Metrics,
+    Metadata,
+    Link,
+    OrderedList,
+)
 
 __version__ = "0.1.0"

--- a/external/report/report/create_report.py
+++ b/external/report/report/create_report.py
@@ -1,6 +1,6 @@
 import datetime
 import os
-from typing import Mapping, Sequence, Union
+from typing import Any, Mapping, Sequence, Union
 
 from jinja2 import Template
 from pytz import timezone
@@ -88,6 +88,15 @@ class Link:
 
     def __repr__(self) -> str:
         return f'<a href="{self.url}">{self.tag}</a>'
+
+
+class OrderedList:
+    def __init__(self, items: Sequence[Any]):
+        self.items = items
+
+    def __repr__(self) -> str:
+        items_li = [f"<li>{item}</li>" for item in self.items]
+        return "<ol>\n" + "\n".join(items_li) + "\n</ol>"
 
 
 def resolve_plot(obj):

--- a/external/report/report/create_report.py
+++ b/external/report/report/create_report.py
@@ -91,7 +91,7 @@ class Link:
 
 
 class OrderedList:
-    def __init__(self, items: Sequence[Any]):
+    def __init__(self, *items: Any):
         self.items = items
 
     def __repr__(self) -> str:

--- a/external/report/tests/test_report.py
+++ b/external/report/tests/test_report.py
@@ -1,5 +1,5 @@
 import os
-from report import __version__, create_html
+from report import __version__, create_html, OrderedList
 from report.create_report import _save_figure, insert_report_figure
 
 
@@ -46,3 +46,8 @@ def test__save_figure(tmpdir):
     with open(os.path.join(output_dir, filepath_relative_to_report), "r") as f:
         saved_data = f.read()
     assert saved_data.replace("\n", "") == fig.content
+
+
+def test_OrderedList_repr():
+    result = str(OrderedList(["item1", "item2"]))
+    assert result == "<ol>\n<li>item1</li>\n<li>item2</li>\n</ol>"

--- a/external/report/tests/test_report.py
+++ b/external/report/tests/test_report.py
@@ -49,5 +49,5 @@ def test__save_figure(tmpdir):
 
 
 def test_OrderedList_repr():
-    result = str(OrderedList(["item1", "item2"]))
+    result = str(OrderedList("item1", "item2"))
     assert result == "<ol>\n<li>item1</li>\n<li>item2</li>\n</ol>"

--- a/external/vcm/tests/test_calc.py
+++ b/external/vcm/tests/test_calc.py
@@ -12,6 +12,7 @@ from vcm.calc.thermo import (
 )
 from vcm.calc.calc import local_time, apparent_source
 from vcm.cubedsphere.constants import COORD_Z_CENTER, COORD_Z_OUTER
+from vcm.calc.histogram import histogram
 
 
 @pytest.mark.parametrize("toa_pressure", [0, 5])
@@ -119,3 +120,15 @@ def test_apparent_source():
         s_dim="forecast_time",
     )
     assert Q1_forecast3 == pytest.approx((2.0 / (15 * 60)) - (4.0 / 60))
+
+
+def test_histogram():
+    data = xr.DataArray(
+        np.reshape(np.arange(0, 40, 2), (5, 4)), dims=["x", "y"], name="temperature"
+    )
+    coords = {"temperature_bins": [0, 30]}
+    expected_count = xr.DataArray([15, 5], coords=coords, dims="temperature_bins")
+    expected_width = xr.DataArray([30, 10], coords=coords, dims="temperature_bins")
+    count, width = histogram(data, bins=[0, 30, 40])
+    xr.testing.assert_equal(count, expected_count)
+    xr.testing.assert_equal(width, expected_width)

--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -29,6 +29,7 @@ from .calc.thermo import (
     column_integrated_heating_from_isobaric_transition,
     column_integrated_heating_from_isochoric_transition,
 )
+from .calc.histogram import histogram
 
 from .interpolate import (
     interpolate_to_pressure_levels,

--- a/external/vcm/vcm/calc/histogram.py
+++ b/external/vcm/vcm/calc/histogram.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Any, Hashable, Mapping, Tuple
 
 import numpy as np
 import xarray as xr
@@ -17,7 +17,7 @@ def histogram(da: xr.DataArray, **kwargs) -> Tuple[xr.DataArray, xr.DataArray]:
     """
     coord_name = f"{da.name}_bins" if da.name is not None else "bins"
     count, bins = np.histogram(da, **kwargs)
-    coords = {coord_name: bins[:-1]}
+    coords: Mapping[Hashable, Any] = {coord_name: bins[:-1]}
     width = bins[1:] - bins[:-1]
     width_da = xr.DataArray(width, coords=coords, dims=[coord_name])
     count_da = xr.DataArray(count, coords=coords, dims=[coord_name])

--- a/external/vcm/vcm/calc/histogram.py
+++ b/external/vcm/vcm/calc/histogram.py
@@ -1,0 +1,28 @@
+from typing import Tuple
+
+import numpy as np
+import xarray as xr
+
+
+def histogram(da: xr.DataArray, **kwargs) -> Tuple[xr.DataArray, xr.DataArray]:
+    """Compute histogram and return tuple of counts and bin widths.
+    
+    Args:
+        da: input data
+        kwargs: optional parameters to pass on to np.histogram
+
+    Return:
+        counts, bin_widths tuple of xr.DataArrays. The coordinate of both arrays is
+        equal to the left side of the histogram bins.
+    """
+    coord_name = f"{da.name}_bins" if da.name is not None else "bins"
+    count, bins = np.histogram(da, **kwargs)
+    coords = {coord_name: bins[:-1]}
+    width = bins[1:] - bins[:-1]
+    width_da = xr.DataArray(width, coords=coords, dims=[coord_name])
+    count_da = xr.DataArray(count, coords=coords, dims=[coord_name])
+    if "units" in da.attrs:
+        count_da[coord_name].attrs["units"] = da.units
+        width_da[coord_name].attrs["units"] = da.units
+        width_da.attrs["units"] = da.units
+    return count_da, width_da

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -502,11 +502,13 @@ def compute_histogram(prognostic, verification, grid):
         count, bins = np.histogram(
             prognostic[varname], bins=HISTOGRAM_BINS[varname], density=True
         )
-        bin_midpoints = 0.5 * (bins[:-1] + bins[1:])
-        coords = {f"{varname}_bins": bin_midpoints}
+        coords = {f"{varname}_bins": bins[:-1]}
+        width = bins[1:] - bins[:-1]
+        width_da = xr.DataArray(width, coords=coords, dims=list(coords.keys()))
         count_da = xr.DataArray(count, coords=coords, dims=list(coords.keys()))
         count_da[f"{varname}_bins"].attrs["units"] = prognostic[varname].units
         counts[varname] = count_da
+        counts[f"{varname}_bin_width"] = width_da
     return _assign_diagnostic_time_attrs(counts, prognostic)
 
 

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -23,7 +23,7 @@ import fsspec
 
 from toolz import curry
 from collections import defaultdict
-from typing import Dict, Callable, Mapping, Tuple, Union
+from typing import Dict, Callable, Mapping, Union
 
 from joblib import Parallel, delayed
 

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -23,7 +23,7 @@ import fsspec
 
 from toolz import curry
 from collections import defaultdict
-from typing import Dict, Callable, Mapping, Union
+from typing import Dict, Callable, Mapping, Tuple, Union
 
 from joblib import Parallel, delayed
 
@@ -499,16 +499,11 @@ def compute_histogram(prognostic, verification, grid):
     logger.info("Computing histograms for physics diagnostics")
     counts = xr.Dataset()
     for varname in prognostic.data_vars:
-        count, bins = np.histogram(
+        count, width = vcm.histogram(
             prognostic[varname], bins=HISTOGRAM_BINS[varname], density=True
         )
-        coords = {f"{varname}_bins": bins[:-1]}
-        width = bins[1:] - bins[:-1]
-        width_da = xr.DataArray(width, coords=coords, dims=list(coords.keys()))
-        count_da = xr.DataArray(count, coords=coords, dims=list(coords.keys()))
-        count_da[f"{varname}_bins"].attrs["units"] = prognostic[varname].units
-        counts[varname] = count_da
-        counts[f"{varname}_bin_width"] = width_da
+        counts[varname] = count
+        counts[f"{varname}_bin_width"] = width
     return _assign_diagnostic_time_attrs(counts, prognostic)
 
 

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -493,7 +493,7 @@ for mask_type in ["global", "land", "sea"]:
 
 @add_to_diags("physics")
 @diag_finalizer("histogram")
-@transform.apply("resample_time", "3H", inner_join=True)
+@transform.apply("resample_time", "3H", inner_join=True, method="mean")
 @transform.apply("subset_variables", list(HISTOGRAM_BINS.keys()))
 def compute_histogram(prognostic, verification, grid):
     logger.info("Computing histograms for physics diagnostics")

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/compute.py
@@ -494,20 +494,11 @@ for mask_type in ["global", "land", "sea"]:
 @add_to_diags("physics")
 @diag_finalizer("histogram")
 @transform.apply("resample_time", "3H", inner_join=True)
-@transform.apply("subset_variables", HISTOGRAM_BINS.keys())
+@transform.apply("subset_variables", list(HISTOGRAM_BINS.keys()))
 def compute_histogram(prognostic, verification, grid):
     logger.info("Computing histograms for physics diagnostics")
     counts = xr.Dataset()
     for varname in prognostic.data_vars:
-        # bins = HISTOGRAM_BINS[varname]
-        # counts[varname] = prognostic.groupby_bins(varname, bins).count()[varname]
-        # bin_midpoints = [x.item().mid for x in counts[f"{varname}_bins"]]
-        # counts = counts.assign_coords({f"{varname}_bins": bin_midpoints})
-        # counts[varname] /= counts[varname].sum()
-        # counts[varname] /= bins[1:] - bins[:1]
-        # counts[varname].attrs["units"] = f"({prognostic[varname].units})^-1"
-        # counts[varname].attrs["long_name"] = "Frequency"
-        # counts[f"{varname}_bins"].attrs = prognostic[varname].attrs
         count, bins = np.histogram(
             prognostic[varname], bins=HISTOGRAM_BINS[varname], density=True
         )

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/computed_diagnostics.py
@@ -274,11 +274,6 @@ def detect_folders(
     bucket: str, fs: fsspec.AbstractFileSystem,
 ) -> Mapping[str, DiagnosticFolder]:
     diag_ncs = fs.glob(os.path.join(bucket, "*", "diags.nc"))
-    if len(diag_ncs) < 2:
-        raise ValueError(
-            "Plots require more than 1 diagnostic directory in"
-            f" {bucket} for holoviews plots to display correctly."
-        )
     return {
         Path(url).parent.name: DiagnosticFolder(fs, Path(url).parent.as_posix())
         for url in diag_ncs

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/constants.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray as xr
 from typing import Tuple
 
@@ -135,3 +136,5 @@ PRESSURE_INTERPOLATED_VARS = [
     "dQu",
     "dQv",
 ]
+
+HISTOGRAM_BINS = {"total_precip_to_surface": np.logspace(-1, np.log10(500), 101)}

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/constants.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/constants.py
@@ -137,4 +137,6 @@ PRESSURE_INTERPOLATED_VARS = [
     "dQv",
 ]
 
-HISTOGRAM_BINS = {"total_precip_to_surface": np.logspace(-1, np.log10(500), 101)}
+PRECIP_RATE = "total_precip_to_surface"
+HISTOGRAM_BINS = {PRECIP_RATE: np.logspace(-1, np.log10(500), 101)}
+PERCENTILES = [25, 50, 75, 90, 99, 99.9]

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
@@ -13,7 +13,7 @@ from typing import Callable, Mapping
 import numpy as np
 import xarray as xr
 from toolz import curry
-from .constants import HORIZONTAL_DIMS
+from .constants import HORIZONTAL_DIMS, PERCENTILES
 import json
 
 _METRICS = []
@@ -138,7 +138,7 @@ def rmse_time_mean(diags):
     return rms_of_time_mean_bias
 
 
-for percentile in [25, 50, 75, 90, 99, 99.9]:
+for percentile in PERCENTILES:
 
     @add_to_metrics(f"percentile_{percentile}")
     def percentile_metric(diags, p=percentile):

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
@@ -157,8 +157,19 @@ for percentile in PERCENTILES:
 
 
 def compute_percentile(
-    p: float, freq: np.ndarray, bins: np.ndarray, bin_widths: np.ndarray
-):
+    percentile: float, freq: np.ndarray, bins: np.ndarray, bin_widths: np.ndarray
+) -> float:
+    """Compute percentile given normalized histogram.
+
+    Args:
+        percentile: value between 0 and 100
+        freq: array of frequencies normalized by bin widths
+        bins: values of left sides of bins
+        bin_widths: values of bin widths
+
+    Returns:
+        value of distribution at percentile
+    """
     cumulative_distribution = np.cumsum(freq * bin_widths)
     if np.abs(cumulative_distribution[-1] - 1) > 1e-6:
         raise ValueError(
@@ -166,7 +177,8 @@ def compute_percentile(
             "Ensure that histogram is computed with density=True."
         )
     bin_midpoints = bins + 0.5 * bin_widths
-    return bin_midpoints[np.argmin(np.abs(cumulative_distribution - p / 100))]
+    closest_index = np.argmin(np.abs(cumulative_distribution - percentile / 100))
+    return bin_midpoints[closest_index]
 
 
 def restore_units(source, target):

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
@@ -18,9 +18,6 @@ import json
 
 _METRICS = []
 GRID_VARS = ["lon", "lat", "lonb", "latb", "area"]
-QUANTILE_LIMITS = {
-    "total_precip_to_surface": ((0.1, 1), (1, 10), (10, 100), (100, None))
-}
 
 
 def grab_diag(ds, name):

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/metrics.py
@@ -141,7 +141,7 @@ def rmse_time_mean(diags):
 for percentile in [25, 50, 75, 90, 99, 99.9]:
 
     @add_to_metrics(f"percentile_{percentile}")
-    def time_and_global_mean_bias(diags, p=percentile):
+    def percentile_metric(diags, p=percentile):
         histogram = grab_diag(diags, "histogram")
         percentiles = xr.Dataset()
         data_vars = [v for v in histogram.data_vars if not v.endswith("bin_width")]

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -331,12 +331,12 @@ def generic_metric_plot(metrics: RunMetrics, metric_type: str) -> hv.HoloMap:
 
 navigation = OrderedList(
     Link("Home", "index.html"),
-    Link("Process diagnostics", "process.html"),
+    Link("Process diagnostics", "process_diagnostics.html"),
     Link("Latitude versus time hovmoller", "hovmoller.html"),
     Link("Time-mean maps", "maps.html"),
     Link("Time-mean zonal-pressure profiles", "zonal_pressure.html"),
 )
-navigation = [navigation]  # must be iterable for Jinja HTML template
+navigation = [navigation]  # must be iterable for create_html template
 
 
 def render_index(metadata, diagnostics, metrics, movie_links):

--- a/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
+++ b/workflows/prognostic_run_diags/tests/test_computed_diagnostics.py
@@ -49,16 +49,6 @@ def test_ComputedDiagnosticsList_from_urls():
     assert isinstance(result.folders["1"], DiagnosticFolder)
 
 
-def test_detect_folders_fail_less_than_2(tmpdir):
-
-    fs = fsspec.filesystem("file")
-
-    tmpdir.mkdir("rundir1").join("diags.nc").write("foobar")
-
-    with pytest.raises(ValueError):
-        detect_folders(tmpdir, fs)
-
-
 def test_get_movie_links(tmpdir):
     domain = "http://www.domain.com"
     rdirs = ["rundir1", "rundir2"]

--- a/workflows/prognostic_run_diags/tests/test_integration.sh
+++ b/workflows/prognostic_run_diags/tests/test_integration.sh
@@ -21,9 +21,6 @@ gsutil cp /tmp/$random/metrics.json $OUTPUT/run1/metrics.json
 # generate movies for short sample prognostic run
 prognostic_run_diags movie --n_jobs 1 --n_timesteps 2 $RUN $OUTPUT/run1
 
-# make a second copy of diags/metrics since generate_report.py needs at least two runs
-gsutil -m cp -r $OUTPUT/run1 $OUTPUT/run2
-
 # generate report based on diagnostics computed above
 prognostic_run_diags report $OUTPUT $OUTPUT
 

--- a/workflows/prognostic_run_diags/tests/test_metrics.py
+++ b/workflows/prognostic_run_diags/tests/test_metrics.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+from fv3net.diagnostics.prognostic_run.metrics import compute_percentile
+
+
+@pytest.mark.parametrize(
+    ["percentile", "expected_value"],
+    [(0, 0.5), (5, 0.5), (10, 0.5), (20, 1.5), (45, 2.5), (99, 3.5)],
+)
+def test_compute_percentile(percentile, expected_value):
+    bins = np.array([0, 1, 2, 3])
+    bin_widths = np.array([1, 1, 1, 1])
+    frequency = np.array([0.1, 0.1, 0.4, 0.4])
+    value = compute_percentile(percentile, frequency, bins, bin_widths)
+    assert value == expected_value
+
+
+def test_compute_percentile_raise_value_error():
+    bins = np.array([0, 1, 2, 3])
+    bin_widths = np.array([1, 1, 1, 0.5])
+    frequency = np.array([0.1, 0.1, 0.4, 0.4])
+    with pytest.raises(ValueError):
+        compute_percentile(0, frequency, bins, bin_widths)

--- a/workflows/prognostic_run_diags/tests/test_savediags.py
+++ b/workflows/prognostic_run_diags/tests/test_savediags.py
@@ -2,8 +2,6 @@ import fv3net.diagnostics.prognostic_run.compute as savediags
 import cftime
 import numpy as np
 import xarray as xr
-import fsspec
-from unittest.mock import Mock
 
 import pytest
 
@@ -27,33 +25,6 @@ def grid():
     pytest.skip()
     # TODO replace these fixtures with synthetic data generation
     return xr.open_dataset("grid.nc").load()
-
-
-def test_dump_nc(tmpdir):
-    ds = xr.Dataset({"a": (["x"], [1.0])})
-
-    path = str(tmpdir.join("data.nc"))
-    with fsspec.open(path, "wb") as f:
-        savediags.dump_nc(ds, f)
-
-    ds_compare = xr.open_dataset(path)
-    xr.testing.assert_equal(ds, ds_compare)
-
-
-def test_dump_nc_no_seek():
-    """
-    GCSFS file objects raise an error when seek is called in write mode::
-
-        if not self.mode == "rb":
-            raise ValueError("Seek only available in read mode")
-            ValueError: Seek only available in read mode
-
-    """
-    ds = xr.Dataset({"a": (["x"], [1.0])})
-    m = Mock()
-
-    savediags.dump_nc(ds, m)
-    m.seek.assert_not_called()
 
 
 @pytest.mark.parametrize("func", savediags._DIAG_FNS)


### PR DESCRIPTION
Useful to show a histogram of precipitation on prognostic run reports. Example report [HERE](https://storage.googleapis.com/vcm-ml-public/oliwm/test/new-report/index.html).

Significant internal changes:
- Added function to compute histograms of arbitrary variables. For now, just doing surface precipitation rate.
- Create new `process_diagnostics.html` page to the prog run report. Moved diurnal cycle there, and added plot of precipitation histogram.
- Added metric to compute percentiles from above histograms. For now, computing 25th, 50th, 75th, 90, 99, and 99.9th percentiles. e.g.:

```
"percentile_25/total_precip_to_surface": {
      "value": 0.3747434426709828,
      "units": "mm/day"
}
```

Sped up report test by only creating report for a single run (since no longer require >1 run for report generation).

- [x] Tests added
