### PR TITLE
Don't use quotes around $flags in memoized_compute_diagnostics.sh

### DIFF
--- a/workflows/prognostic_run_diags/scripts/memoized_compute_diagnostics.sh
+++ b/workflows/prognostic_run_diags/scripts/memoized_compute_diagnostics.sh
@@ -31,7 +31,7 @@ if [[ $diagsExitCode -eq 0 && $metricsExitCode -eq 0 ]]; then
     echo "Prognostic run diagnostics detected in cache for given run. Using cached diagnostics."
 else
     echo "No prognostic run diagnostics detected in cache for given run. Computing diagnostics and adding to cache."	
-    prognostic_run_diags save $flags $run diags.nc
+    prognostic_run_diags save $flags "$run" diags.nc
     prognostic_run_diags metrics diags.nc > metrics.json
     gsutil cp diags.nc "$cacheURL/diags.nc"
     gsutil cp metrics.json "$cacheURL/metrics.json"

--- a/workflows/prognostic_run_diags/scripts/memoized_compute_diagnostics.sh
+++ b/workflows/prognostic_run_diags/scripts/memoized_compute_diagnostics.sh
@@ -31,7 +31,7 @@ if [[ $diagsExitCode -eq 0 && $metricsExitCode -eq 0 ]]; then
     echo "Prognostic run diagnostics detected in cache for given run. Using cached diagnostics."
 else
     echo "No prognostic run diagnostics detected in cache for given run. Computing diagnostics and adding to cache."	
-    prognostic_run_diags save "$flags" "$run" diags.nc
+    prognostic_run_diags save $flags $run diags.nc
     prognostic_run_diags metrics diags.nc > metrics.json
     gsutil cp diags.nc "$cacheURL/diags.nc"
     gsutil cp metrics.json "$cacheURL/metrics.json"


### PR DESCRIPTION
Fixes bug introduced in #1262 when satisfying shellcheck (if `$flags` is surrounded by quotes the script fails if `$flags` is an empty variable, e.g. when the default verification data is used).