### PR TITLE
Don't call gsutil cp if output is equal to cacheURL

### DIFF
--- a/workflows/prognostic_run_diags/scripts/memoized_compute_diagnostics.sh
+++ b/workflows/prognostic_run_diags/scripts/memoized_compute_diagnostics.sh
@@ -37,5 +37,7 @@ else
     gsutil cp metrics.json "$cacheURL/metrics.json"
 fi
 
-gsutil cp "$cacheURL/diags.nc" "$output/diags.nc"
-gsutil cp "$cacheURL/metrics.json" "$output/metrics.json"
+if [[ $output != $cacheURL ]]; then
+    gsutil cp "$cacheURL/diags.nc" "$output/diags.nc"
+    gsutil cp "$cacheURL/metrics.json" "$output/metrics.json"
+fi


### PR DESCRIPTION
`gsutil cp SOURCE TARGET` fails if TARGET==SOURCE, so adjust `memoized_compute_diagnostics.sh` script to handle this case.