### PR TITLE
Prognostic report: fix contour cbar levels across rows

### DIFF
--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -109,7 +109,14 @@ def plot_2d_matplotlib(
             if contour:
                 cbar_levels = np.arange(-vmax, vmax, step=2 * vmax / CONTOUR_LEVELS)
                 xr.plot.contourf(
-                    v, ax=ax, x=x, y=y, vmax=vmax, levels=cbar_levels, **opts
+                    v,
+                    ax=ax,
+                    x=x,
+                    y=y,
+                    vmax=vmax,
+                    levels=cbar_levels,
+                    extend="both",
+                    **opts,
                 )
             else:
                 v.plot(ax=ax, x=x, y=y, vmax=vmax, **opts)

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -9,6 +9,8 @@ import xarray as xr
 import cartopy.crs as ccrs
 import jinja2
 import matplotlib.pyplot as plt
+import numpy as np
+
 from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     RunDiagnostics,
     RunMetrics,
@@ -77,6 +79,7 @@ CBAR_RANGE = {
     "specific_humidity_pressure_level_zonal_bias": 1e-3,
     "vertical_wind_pressure_level_zonal_bias": 0.02,
 }
+CONTOUR_LEVELS = 20
 
 
 def plot_2d_matplotlib(
@@ -96,7 +99,6 @@ def plot_2d_matplotlib(
     x, y = dims
 
     variables_to_plot = run_diags.matching_variables(varfilter)
-
     for run in run_diags.runs:
         for varname in variables_to_plot:
             vmax = CBAR_RANGE.get(varname)
@@ -105,7 +107,10 @@ def plot_2d_matplotlib(
             long_name_and_units = f"{v.long_name} [{v.units}]"
             fig, ax = plt.subplots()
             if contour:
-                xr.plot.contourf(v, ax=ax, x=x, y=y, vmax=vmax, **opts)
+                cbar_levels = np.arange(-vmax, vmax, step=2 * vmax / CONTOUR_LEVELS)
+                xr.plot.contourf(
+                    v, ax=ax, x=x, y=y, vmax=vmax, levels=cbar_levels, **opts
+                )
             else:
                 v.plot(ax=ax, x=x, y=y, vmax=vmax, **opts)
             if ylabel:
@@ -151,7 +156,6 @@ def plot_cubed_sphere_map(
         metrics_for_title = {}
 
     variables_to_plot = run_diags.matching_variables(varfilter)
-
     for run in run_diags.runs:
         for varname in variables_to_plot:
             logging.info(f"plotting {varname} in {run}")


### PR DESCRIPTION
Currently the zonal-pressure bias plots are hard to compare across experiments because matplotlib is inconsistent in selecting color levels for a fixed vmax. This PR fixes the cbar levels across the row.

before:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/16710132/124037912-2b147100-d9b5-11eb-8e9d-6a1761c12519.png">

after:
<img width="1548" alt="image" src="https://user-images.githubusercontent.com/16710132/124039538-f950d980-d9b7-11eb-8ad6-eb7bd6d164ce.png">