### PR TITLE
fv3fit: add DerivedModel predictor

### DIFF
--- a/external/fv3fit/docs/derived_model.rst
+++ b/external/fv3fit/docs/derived_model.rst
@@ -1,0 +1,29 @@
+.. configuration_:
+
+Derived prediction models
+=========
+
+The DerivedModel class wraps a trained ML model to include prediction variables that may be derived from the ML prediction. 
+Models that include "derived" prediction variables that can be defined manually, by writing a configuration yaml named 
+``derived_model.yaml`` and a ``name`` file to a directory. 
+
+
+.. code-block:: yaml
+
+    model: gs://vcm-ml-scratch/annak/2021-07-07-nn-no-net-sw/trained_model
+    additional_input_variables:
+        - surface_diffused_shortwave_albedo
+    derived_output_variables:
+        - net_downward_shortwave_sfc_flux_derived
+
+A ``name`` file can be written using:
+
+.. code-block:: bash
+
+    echo -n derived_model > name
+
+It is important that the created ``name`` file does not have a newline, as can be done with ``echo -n``.
+
+The resulting directory with these two files ``name`` and ``derived_model.yaml`` can be used as a model directory in prognostic run.
+Offline diagnostics can be computed for a DerivedModel if the base ML model's model training configuration yaml in the derived_model directory;
+however, only the base ML model's outputs will be included in the report, so you should just use the base model directly in the offline diags.

--- a/external/fv3fit/docs/derived_model.rst
+++ b/external/fv3fit/docs/derived_model.rst
@@ -14,7 +14,7 @@ Models that include "derived" prediction variables that can be defined manually,
     additional_input_variables:
         - surface_diffused_shortwave_albedo
     derived_output_variables:
-        - net_downward_shortwave_sfc_flux_derived
+        - net_shortwave_sfc_flux_derived
 
 A ``name`` file can be written using:
 

--- a/external/fv3fit/docs/index.rst
+++ b/external/fv3fit/docs/index.rst
@@ -14,6 +14,7 @@ The package provides :py:func:`fv3fit.dump` and :py:func:`fv3fit.load` functions
    configuration
    ensembles
    api
+   derived_model
 
 Indices and tables
 ==================

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -213,6 +213,19 @@ class DenseHyperparameters:
 
 
 @dataclasses.dataclass
+class DerivedModelHyperparameters:
+    base_model_type: str
+    hyperparameters: dict
+    derived_variables: Sequence[str]
+
+    def __post_init__(self):
+        hyperparameter_class = get_hyperparameter_class(self.base_model_type)
+        self.base_model_hyperparameters = dacite.from_dict(
+            data_class=hyperparameter_class, data=self.hyperparameters
+        )
+
+
+@dataclasses.dataclass
 class RandomForestHyperparameters:
     """
     Configuration for training a random forest based model.

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -213,41 +213,6 @@ class DenseHyperparameters:
 
 
 @dataclasses.dataclass
-class DerivedModelHyperparameters:
-    """Configuration for training a DerivedModel, which wraps
-    the base_model_type and adds derived_variables to its output
-    predictions.
-
-    Example usage: The base model predicts net DW shortwave flux, which is
-    used in combination with additional input albedo to add a 'derived'
-    prediction for net shortwave flux.
-
-    Args:
-        base_model_type: Class of base model, e.g. DenseModel, RandomForest
-        hyperparameters: Hyperparameters of the base model. These must
-            correspond to its hyperparamter class, e.g.
-            DenseModelHyperparameters
-        derived_variables: List of outputs that are not directly predicted by
-            the base model.
-        additional_inputs: List of additional variables needed to make the
-            derived prediction which are **not** used as input variables for
-            the base ML model. If these are already used as features in the ML
-            model, there is no need to include them here.
-    """
-
-    base_model_type: str
-    hyperparameters: dict
-    derived_variables: Sequence[str]
-    additional_inputs: Sequence[str]
-
-    def __post_init__(self):
-        hyperparameter_class = get_hyperparameter_class(self.base_model_type)
-        self.base_model_hyperparameters = dacite.from_dict(
-            data_class=hyperparameter_class, data=self.hyperparameters
-        )
-
-
-@dataclasses.dataclass
 class RandomForestHyperparameters:
     """
     Configuration for training a random forest based model.

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -214,9 +214,31 @@ class DenseHyperparameters:
 
 @dataclasses.dataclass
 class DerivedModelHyperparameters:
+    """Configuration for training a DerivedModel, which wraps
+    the base_model_type and adds derived_variables to its output
+    predictions.
+
+    Example usage: The base model predicts net DW shortwave flux, which is
+    used in combination with additional input albedo to add a 'derived'
+    prediction for net shortwave flux.
+
+    Args:
+        base_model_type: Class of base model, e.g. DenseModel, RandomForest
+        hyperparameters: Hyperparameters of the base model. These must
+            correspond to its hyperparamter class, e.g.
+            DenseModelHyperparameters
+        derived_variables: List of outputs that are not directly predicted by
+            the base model.
+        additional_inputs: List of additional variables needed to make the
+            derived prediction which are **not** used as input variables for
+            the base ML model. If these are already used as features in the ML
+            model, there is no need to include them here.
+    """
+
     base_model_type: str
     hyperparameters: dict
     derived_variables: Sequence[str]
+    additional_inputs: Sequence[str]
 
     def __post_init__(self):
         hyperparameter_class = get_hyperparameter_class(self.base_model_type)

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -1,10 +1,135 @@
-from typing import Iterable, Set, Hashable
+from typing import Iterable, Set, Hashable, Sequence
 import fsspec
 import yaml
 import os
 import xarray as xr
+import vcm
+import dataclasses
+
 from . import io
 from .predictor import Predictor
+from .config import (
+    DerivedModelHyperparameters,
+    register_training_function,
+    get_training_function,
+)
+
+
+@register_training_function("DerivedModel", DerivedModelHyperparameters)
+def train_derived_model(
+    input_variables: Iterable[str],
+    output_variables: Iterable[str],
+    hyperparameters: DerivedModelHyperparameters,
+    train_batches: Sequence[xr.Dataset],
+    validation_batches: Sequence[xr.Dataset],
+):
+
+    model = DerivedModel(
+        "sample",
+        base_model_input_variables=input_variables,
+        output_variables=output_variables,
+        hyperparameters=hyperparameters,
+    )
+    # TODO: make use of validation_batches, currently validation dataset is
+    # passed through hyperparameters.fit_kwargs
+    model.fit(train_batches, validation_batches)
+    return model
+
+
+@io.register("derived_model")
+class DerivedModel(Predictor):
+    _BASE_MODEL_DIRECTORY = "base_model_data"
+    _HYPERPARAMETERS_FILENAME = "hyperparameters.yml"
+    _OPTIONS_FILENAME = "options.yml"
+
+    def __init__(
+        self,
+        sample_dim_name: str,
+        base_model_input_variables: Iterable[str],
+        output_variables: Iterable[str],
+        hyperparameters: DerivedModelHyperparameters,
+    ):
+        """
+
+        Args:
+            sample_dim_name: name of stacked sample dim
+            base_model_input_variables: input variables for baseML model
+                predictions, *should not* include inputs needed for derived
+                prediction if they are not ML features. These additional
+                inputs should be specified in
+                DerivedModelHyperparameters.additional_inputs
+            output_variables: output variables of the base ML model
+                i.e. does not include the derived prediction variables, these
+                are specified in DerivedModelHyperparameters.derived_variables
+            hyperparameters: DerivedModelHyperparameters class
+        
+
+
+        """
+
+        full_input_variables = sorted(
+            list(set(base_model_input_variables + hyperparameters.additional_inputs))
+        )
+
+        # DerivedModel.input_variables (what the prognostic run uses to grab
+        # necessary state for input to .predict()) is the set of
+        # base_model_input_variables arg and hyperparameters.additional_inputs.
+        super().__init__(sample_dim_name, full_input_variables, output_variables)
+        self._hyperparameters = hyperparameters
+        self._base_model_type = hyperparameters.base_model_type
+        self._base_model_input_variables = base_model_input_variables
+        self._base_model_hyperparameters = hyperparameters.base_hyperparameters
+        self._derived_variables = hyperparameters.derived_variables
+
+        self._base_model = None
+
+    def fit(
+        self, batches: Sequence[xr.Dataset], validation_batches: Sequence[xr.Dataset]
+    ):
+        # calls the training function for the underlying ML model
+        base_training_function = get_training_function(self._base_model_type)
+        base_model = base_training_function(
+            self._base_model_input_variables,
+            self._output_variables,
+            self._base_model_hyperparameters,
+            batches,
+            validation_batches,
+        )
+        self._base_model = base_model
+
+    def predict(self, X: xr.Dataset) -> xr.Dataset:
+        base_prediction = self._base_model.predict(X)
+        # derived prediction variables may need additional inputs to compute
+        derived_mapping = vcm.DerivedMapping(xr.merge([X, base_prediction]))
+        derived_prediction = derived_mapping.dataset(self._derived_variables)
+        return xr.merge([base_prediction, derived_prediction])
+
+    def dump(self, path: str):
+        self._base_model.dump(os.path.join(path, self._BASE_MODEL_DIRECTORY))
+        with fsspec.open(os.path.join(path, self._HYPERPARAMETERS_FILENAME), "w") as f:
+            hyperparameters = dataclasses.asdict(self._hyperparameters)
+            yaml.safe_dump(hyperparameters, f)
+        options = {
+            "sample_dim_name": self._sample_dim_name,
+            "base_model_input_variables": self._base_model_input_variables,
+            "output_variables": self._output_variables,
+        }
+        with fsspec.open(os.path.join(path, self._OPTIONS_FILENAME), "w") as f:
+            yaml.safe_dump(options, f)
+
+    @classmethod
+    def load(cls, path: str) -> "DerivedModel":
+        with fsspec.open(os.path.join(path, cls._OPTIONS_FILENAME), "r") as f:
+            options = yaml.safe_load(f)
+        with fsspec.open(os.path.join(path, cls._HYPERPARAMETERS_FILENAME), "r") as f:
+            hyperparameters_dict = yaml.safe_load(f)
+            hyperparameters = DerivedModelHyperparameters(hyperparameters_dict)
+
+        derived_model = cls(**options, hyperparameters=hyperparameters,)
+        derived_model._base_model = io.load(
+            os.path.join(path, cls._BASE_MODEL_DIRECTORY)
+        )
+        return derived_model
 
 
 @io.register("ensemble")

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -1,101 +1,53 @@
-from typing import Iterable, Set, Hashable, Sequence
+from typing import Iterable, Set, Hashable
 import fsspec
 import yaml
 import os
 import xarray as xr
 import vcm
-import dataclasses
 
 from . import io
 from .predictor import Predictor
-from .config import (
-    DerivedModelHyperparameters,
-    register_training_function,
-    get_training_function,
-)
-
-
-@register_training_function("DerivedModel", DerivedModelHyperparameters)
-def train_derived_model(
-    input_variables: Iterable[str],
-    output_variables: Iterable[str],
-    hyperparameters: DerivedModelHyperparameters,
-    train_batches: Sequence[xr.Dataset],
-    validation_batches: Sequence[xr.Dataset],
-):
-
-    model = DerivedModel(
-        "sample",
-        base_model_input_variables=input_variables,
-        output_variables=output_variables,
-        hyperparameters=hyperparameters,
-    )
-    # TODO: make use of validation_batches, currently validation dataset is
-    # passed through hyperparameters.fit_kwargs
-    model.fit(train_batches, validation_batches)
-    return model
 
 
 @io.register("derived_model")
 class DerivedModel(Predictor):
+    _CONFIG_FILENAME = "derived_model.yaml"
     _BASE_MODEL_DIRECTORY = "base_model_data"
-    _HYPERPARAMETERS_FILENAME = "hyperparameters.yml"
-    _OPTIONS_FILENAME = "options.yml"
 
     def __init__(
         self,
-        sample_dim_name: str,
-        base_model_input_variables: Iterable[str],
-        output_variables: Iterable[str],
-        hyperparameters: DerivedModelHyperparameters,
+        base_model: Predictor,
+        additional_input_variables: Iterable[str],
+        derived_output_variables: Iterable[str],
     ):
         """
 
         Args:
-            sample_dim_name: name of stacked sample dim
-            base_model_input_variables: input variables for baseML model
-                predictions, *should not* include inputs needed for derived
-                prediction if they are not ML features. These additional
-                inputs should be specified in
-                DerivedModelHyperparameters.additional_inputs
-            output_variables: output variables of the base ML model
-                i.e. does not include the derived prediction variables, these
-                are specified in DerivedModelHyperparameters.derived_variables
-            hyperparameters: DerivedModelHyperparameters class
-        
-
-
+            base_model: trained ML model whose predicted output(s) will be
+                used to derived the additional derived_output_variables.
+            additional_input_variables: inputs needed for derived
+                prediction if they are not ML features.
+            derived_output_variables: derived prediction variables that are NOT
+                part of the set of base_model.output_variables. Should
+                correspond to variables available through vcm.DerivedMapping.
         """
+        self._base_model = base_model
+        self._additional_input_variables = additional_input_variables
+        self._derived_output_variables = derived_output_variables
+
+        sample_dim_name = base_model.sample_dim_name
 
         full_input_variables = sorted(
-            list(set(base_model_input_variables + hyperparameters.additional_inputs))
+            list(set(base_model.input_variables + additional_input_variables))
+        )
+        full_output_variables = sorted(
+            list(set(base_model.output_variables + derived_output_variables))
         )
 
         # DerivedModel.input_variables (what the prognostic run uses to grab
         # necessary state for input to .predict()) is the set of
         # base_model_input_variables arg and hyperparameters.additional_inputs.
-        super().__init__(sample_dim_name, full_input_variables, output_variables)
-        self._hyperparameters = hyperparameters
-        self._base_model_type = hyperparameters.base_model_type
-        self._base_model_input_variables = base_model_input_variables
-        self._base_model_hyperparameters = hyperparameters.base_hyperparameters
-        self._derived_variables = hyperparameters.derived_variables
-
-        self._base_model = None
-
-    def fit(
-        self, batches: Sequence[xr.Dataset], validation_batches: Sequence[xr.Dataset]
-    ):
-        # calls the training function for the underlying ML model
-        base_training_function = get_training_function(self._base_model_type)
-        base_model = base_training_function(
-            self._base_model_input_variables,
-            self._output_variables,
-            self._base_model_hyperparameters,
-            batches,
-            validation_batches,
-        )
-        self._base_model = base_model
+        super().__init__(sample_dim_name, full_input_variables, full_output_variables)
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
         base_prediction = self._base_model.predict(X)
@@ -105,29 +57,21 @@ class DerivedModel(Predictor):
         return xr.merge([base_prediction, derived_prediction])
 
     def dump(self, path: str):
-        self._base_model.dump(os.path.join(path, self._BASE_MODEL_DIRECTORY))
-        with fsspec.open(os.path.join(path, self._HYPERPARAMETERS_FILENAME), "w") as f:
-            hyperparameters = dataclasses.asdict(self._hyperparameters)
-            yaml.safe_dump(hyperparameters, f)
-        options = {
-            "sample_dim_name": self._sample_dim_name,
-            "base_model_input_variables": self._base_model_input_variables,
-            "output_variables": self._output_variables,
-        }
-        with fsspec.open(os.path.join(path, self._OPTIONS_FILENAME), "w") as f:
-            yaml.safe_dump(options, f)
+        raise NotImplementedError(
+            "no dump method yet for this class, you can define one manually "
+            "using instructions at "
+            "http://vulcanclimatemodeling.com/docs/fv3fit/derived_model.html"
+        )
 
     @classmethod
     def load(cls, path: str) -> "DerivedModel":
-        with fsspec.open(os.path.join(path, cls._OPTIONS_FILENAME), "r") as f:
-            options = yaml.safe_load(f)
-        with fsspec.open(os.path.join(path, cls._HYPERPARAMETERS_FILENAME), "r") as f:
-            hyperparameters_dict = yaml.safe_load(f)
-            hyperparameters = DerivedModelHyperparameters(hyperparameters_dict)
-
-        derived_model = cls(**options, hyperparameters=hyperparameters,)
-        derived_model._base_model = io.load(
-            os.path.join(path, cls._BASE_MODEL_DIRECTORY)
+        with fsspec.open(os.path.join(path, cls._CONFIG_FILENAME), "r") as f:
+            config = yaml.safe_load(f)
+        base_model = io.load(config["model"])
+        additional_input_variables = config["additional_input_variables"]
+        derived_output_variables = config["derived_output_variables"]
+        derived_model = cls(
+            base_model, additional_input_variables, derived_output_variables
         )
         return derived_model
 

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -13,7 +13,6 @@ from .predictor import Predictor
 @io.register("derived_model")
 class DerivedModel(Predictor):
     _CONFIG_FILENAME = "derived_model.yaml"
-    _BASE_MODEL_DIRECTORY = "base_model_data"
 
     def __init__(
         self,
@@ -34,6 +33,7 @@ class DerivedModel(Predictor):
         """
         self._base_model = base_model
         self._additional_input_variables = additional_input_variables
+
         self._derived_output_variables = derived_output_variables
 
         sample_dim_name = base_model.sample_dim_name
@@ -48,7 +48,7 @@ class DerivedModel(Predictor):
                 set(list(base_model.output_variables) + list(derived_output_variables))
             )
         )
-
+        self._check_derived_predictions_supported()
         # DerivedModel.input_variables (what the prognostic run uses to grab
         # necessary state for input to .predict()) is the set of
         # base_model_input_variables arg and hyperparameters.additional_inputs.
@@ -90,6 +90,19 @@ class DerivedModel(Predictor):
                 "input dataset needed to compute derived prediction variables. "
                 "Make sure these are present in the data and included in the "
                 "DerivedModel config under additional_input_variables."
+            )
+
+    def _check_derived_predictions_supported(self):
+
+        invalid_derived_variables = np.setdiff1d(
+            self._derived_output_variables, list(vcm.DerivedMapping.VARIABLES)
+        )
+        if len(invalid_derived_variables) > 0:
+            raise ValueError(
+                f"Invalid variables {invalid_derived_variables} "
+                "provided in init arg derived_output_variables. "
+                "Variables in this arg must be available as derived variables "
+                "in vcm.DerivedMapping."
             )
 
 

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -18,8 +18,8 @@ class DerivedModel(Predictor):
     def __init__(
         self,
         base_model: Predictor,
-        additional_input_variables: Iterable[str],
-        derived_output_variables: Iterable[str],
+        additional_input_variables: Iterable[Hashable],
+        derived_output_variables: Iterable[Hashable],
     ):
         """
 
@@ -39,10 +39,14 @@ class DerivedModel(Predictor):
         sample_dim_name = base_model.sample_dim_name
 
         full_input_variables = sorted(
-            list(set(base_model.input_variables + additional_input_variables))
+            list(
+                set(list(base_model.input_variables) + list(additional_input_variables))
+            )
         )
         full_output_variables = sorted(
-            list(set(base_model.output_variables + derived_output_variables))
+            list(
+                set(list(base_model.output_variables) + list(derived_output_variables))
+            )
         )
 
         # DerivedModel.input_variables (what the prognostic run uses to grab

--- a/external/fv3fit/tests/test_derived_model.py
+++ b/external/fv3fit/tests/test_derived_model.py
@@ -24,7 +24,7 @@ def test_derived_prediction():
     derived_model = DerivedModel(
         base_model,
         additional_input_variables=["surface_diffused_shortwave_albedo"],
-        derived_output_variables=["net_downward_shortwave_sfc_flux_derived"],
+        derived_output_variables=["net_shortwave_sfc_flux_derived"],
     )
     ds_in = xr.Dataset(
         data_vars={
@@ -35,14 +35,14 @@ def test_derived_prediction():
         }
     )
     prediction = derived_model.predict(ds_in.stack(sample=["x", "y"]))
-    assert "net_downward_shortwave_sfc_flux_derived" in prediction
+    assert "net_shortwave_sfc_flux_derived" in prediction
 
 
 def test_derived_alert_to_missing_additional_input():
     derived_model = DerivedModel(
         base_model,
         additional_input_variables=["surface_diffused_shortwave_albedo"],
-        derived_output_variables=["net_downward_shortwave_sfc_flux_derived"],
+        derived_output_variables=["net_shortwave_sfc_flux_derived"],
     )
     ds_in = xr.Dataset(
         data_vars={"input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"])}

--- a/external/fv3fit/tests/test_derived_model.py
+++ b/external/fv3fit/tests/test_derived_model.py
@@ -1,0 +1,51 @@
+import fv3fit
+import xarray as xr
+import numpy as np
+import pytest
+from fv3fit._shared.models import DerivedModel
+
+
+sample_dim_name = "sample"
+input_variables = [
+    "input",
+]
+output_variables = [
+    "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface",
+]
+base_model = fv3fit.testing.ConstantOutputPredictor(
+    sample_dim_name, input_variables, output_variables
+)
+base_model.set_outputs(
+    override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface=1.0
+)
+
+
+def test_derived_prediction():
+    derived_model = DerivedModel(
+        base_model,
+        additional_input_variables=["surface_diffused_shortwave_albedo"],
+        derived_output_variables=["net_downward_shortwave_sfc_flux_derived"],
+    )
+    ds_in = xr.Dataset(
+        data_vars={
+            "input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"],),
+            "surface_diffused_shortwave_albedo": xr.DataArray(
+                np.zeros([3, 3]), dims=["x", "y"],
+            ),
+        }
+    )
+    prediction = derived_model.predict(ds_in.stack(sample=["x", "y"]))
+    assert "net_downward_shortwave_sfc_flux_derived" in prediction
+
+
+def test_derived_alert_to_missing_additional_input():
+    derived_model = DerivedModel(
+        base_model,
+        additional_input_variables=["surface_diffused_shortwave_albedo"],
+        derived_output_variables=["net_downward_shortwave_sfc_flux_derived"],
+    )
+    ds_in = xr.Dataset(
+        data_vars={"input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"])}
+    )
+    with pytest.raises(KeyError):
+        derived_model.predict(ds_in.stack(sample=["x", "y"]))

--- a/external/fv3fit/tests/test_derived_model.py
+++ b/external/fv3fit/tests/test_derived_model.py
@@ -49,3 +49,12 @@ def test_derived_alert_to_missing_additional_input():
     )
     with pytest.raises(KeyError):
         derived_model.predict(ds_in.stack(sample=["x", "y"]))
+
+
+def test_invalid_derived_output_variables():
+    with pytest.raises(ValueError):
+        DerivedModel(
+            base_model,
+            additional_input_variables=["surface_diffused_shortwave_albedo"],
+            derived_output_variables=["variable_not_in_DerivedMapping"],
+        )

--- a/external/vcm/tests/test_derived_mapping.py
+++ b/external/vcm/tests/test_derived_mapping.py
@@ -130,3 +130,19 @@ def test_DerivedMapping_unregistered():
     derived_state = DerivedMapping(ds)
     with pytest.raises(KeyError):
         derived_state["latent_heat_flux"]
+
+
+def test_net_downward_shortwave_sfc_flux_derived():
+    ds = xr.Dataset(
+        {
+            "surface_diffused_shortwave_albedo": xr.DataArray(
+                [0, 0.5, 1.0], dims=["x"]
+            ),
+            "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface": (
+                xr.DataArray([1.0, 1.0, 1.0], dims=["x"])
+            ),
+        }
+    )
+    derived_state = DerivedMapping(ds)
+    derived_net_sw = derived_state["net_downward_shortwave_sfc_flux_derived"]
+    np.testing.assert_array_almost_equal(derived_net_sw, [1.0, 0.5, 0.0])

--- a/external/vcm/tests/test_derived_mapping.py
+++ b/external/vcm/tests/test_derived_mapping.py
@@ -144,5 +144,5 @@ def test_net_downward_shortwave_sfc_flux_derived():
         }
     )
     derived_state = DerivedMapping(ds)
-    derived_net_sw = derived_state["net_downward_shortwave_sfc_flux_derived"]
+    derived_net_sw = derived_state["net_shortwave_sfc_flux_derived"]
     np.testing.assert_array_almost_equal(derived_net_sw, [1.0, 0.5, 0.0])

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -125,9 +125,9 @@ def horizontal_wind_tendency_parallel_to_horizontal_wind(self):
     return tendency_projection_onto_wind
 
 
-@DerivedMapping.register("net_downward_shortwave_sfc_flux_derived")
-def net_downward_shortwave_sfc_flux_derived(self):
-    # are these the right variable names?
+@DerivedMapping.register("net_shortwave_sfc_flux_derived")
+def net_shortwave_sfc_flux_derived(self):
+    # Positive = downward direction
     albedo = self["surface_diffused_shortwave_albedo"]
     downward_sfc_shortwave_flux = self[
         "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface"

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -123,3 +123,13 @@ def horizontal_wind_tendency_parallel_to_horizontal_wind(self):
         self["eastward_wind"] * self["dQu"] + self["northward_wind"] * self["dQv"]
     ) / np.linalg.norm((self["eastward_wind"], self["northward_wind"]))
     return tendency_projection_onto_wind
+
+
+@DerivedMapping.register("net_downward_shortwave_sfc_flux_derived")
+def net_downward_shortwave_sfc_flux_derived(self):
+    # are these the right variable names?
+    albedo = self["surface_diffused_shortwave_albedo"]
+    downward_sfc_shortwave_flux = self[
+        "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface"
+    ]
+    return (1 - albedo) * downward_sfc_shortwave_flux

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -13,7 +13,7 @@ class DerivedMapping:
 
     """
 
-    _VARIABLES: Mapping[Hashable, Callable[..., xr.DataArray]] = {}
+    VARIABLES: Mapping[Hashable, Callable[..., xr.DataArray]] = {}
 
     def __init__(self, mapper: Mapping[Hashable, xr.DataArray]):
         self._mapper = mapper
@@ -27,19 +27,19 @@ class DerivedMapping:
         """
 
         def decorator(func):
-            cls._VARIABLES[name] = func
+            cls.VARIABLES[name] = func
             return func
 
         return decorator
 
     def __getitem__(self, key: Hashable) -> xr.DataArray:
-        if key in self._VARIABLES:
-            return self._VARIABLES[key](self)
+        if key in self.VARIABLES:
+            return self.VARIABLES[key](self)
         else:
             return self._mapper[key]
 
     def keys(self):
-        return set(self._mapper) | set(self._VARIABLES)
+        return set(self._mapper) | set(self.VARIABLES)
 
     def _data_arrays(self, keys: Iterable[Hashable]):
         return {key: self[key] for key in keys}

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Mapping, Hashable, Callable, Sequence
+from typing import Mapping, Hashable, Callable, Iterable
 import xarray as xr
 
 import vcm
@@ -15,11 +15,11 @@ class DerivedMapping:
 
     _VARIABLES: Mapping[Hashable, Callable[..., xr.DataArray]] = {}
 
-    def __init__(self, mapper: Mapping[str, xr.DataArray]):
+    def __init__(self, mapper: Mapping[Hashable, xr.DataArray]):
         self._mapper = mapper
 
     @classmethod
-    def register(cls, name: str):
+    def register(cls, name: Hashable):
         """Register a function as a derived variable
 
         Args:
@@ -32,7 +32,7 @@ class DerivedMapping:
 
         return decorator
 
-    def __getitem__(self, key: str) -> xr.DataArray:
+    def __getitem__(self, key: Hashable) -> xr.DataArray:
         if key in self._VARIABLES:
             return self._VARIABLES[key](self)
         else:
@@ -41,10 +41,10 @@ class DerivedMapping:
     def keys(self):
         return set(self._mapper) | set(self._VARIABLES)
 
-    def _data_arrays(self, keys: Sequence[str]):
+    def _data_arrays(self, keys: Iterable[Hashable]):
         return {key: self[key] for key in keys}
 
-    def dataset(self, keys: Sequence[str]) -> xr.Dataset:
+    def dataset(self, keys: Iterable[Hashable]) -> xr.Dataset:
         return xr.Dataset(self._data_arrays(keys))
 
 


### PR DESCRIPTION
This adds a `DerivedModel` class which wraps a "base" ML model and allows additonal derived variables to be returned along with the base ML predicted variables. The immediate use case for this would be to use the ML-predicted downward surface shortwave flux to derive the net surface shortwave flux for updating in the prognostic run. The base ML model can be any other trained fv3fit model. Like the existing `EnsembleModel`, `DerivedModel` has no training function or dump method and instead must be manually created in a model dir with a config file (see added docs). 

The configuration is pretty simple, ex. the yaml below will add albedo to the list of input variables and merge net surface shortwave into the rest of the prediction dataset from the trained ML.
```
    model: gs://vcm-ml-scratch/annak/2021-07-07-nn-no-net-sw/trained_model
    additional_input_variables:
        - surface_diffused_shortwave_albedo
    derived_output_variables:
        - net_shortwave_sfc_flux_derived
```
