### PR TITLE
Update argo download path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
             mv kustomize /usr/local/bin/
 
             # Install argo
-            curl -sLO https://github.com/argoproj/argo/releases/download/v2.11.6/argo-linux-amd64.gz
+            curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v2.11.6/argo-linux-amd64.gz
             gunzip argo-linux-amd64.gz
             chmod +x argo-linux-amd64
             mv ./argo-linux-amd64 /usr/local/bin/argo


### PR DESCRIPTION
The argo project changed the path to their release downloads, which broke the integration test. This updates to the correct URL.