### PR TITLE
fv3fit: dump DerivedModel if derived_output_variables in config

### DIFF
--- a/external/fv3fit/fv3fit/_shared/__init__.py
+++ b/external/fv3fit/fv3fit/_shared/__init__.py
@@ -16,4 +16,4 @@ from .scaler import (
 )
 from .predictor import Predictor
 from .utils import parse_data_path
-from .models import EnsembleModel
+from .models import EnsembleModel, DerivedModel

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -78,7 +78,6 @@ class TrainingConfig:
     sample_dim_name: str = "sample"
     random_seed: Union[float, int] = 0
     derived_output_variables: List[str] = dataclasses.field(default_factory=list)
-    nonfeature_input_variables: List[str] = dataclasses.field(default_factory=list)
 
     @classmethod
     def from_dict(cls, kwargs) -> "TrainingConfig":
@@ -299,7 +298,6 @@ class _ModelTrainingConfig:
     model_path: str = ""
     timesteps_source: str = "timesteps_file"
     derived_output_variables: List[str] = dataclasses.field(default_factory=list)
-    nonfeature_input_variables: List[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self):
         if self.scaler_type == "mass":
@@ -333,7 +331,6 @@ def legacy_config_to_new_config(legacy_config: _ModelTrainingConfig) -> Training
         "random_seed",
         "sample_dim_name",
         "derived_output_variables",
-        "nonfeature_input_variables",
     ]
     if config_class is RandomForestHyperparameters:
         for key in ("scaler_type", "scaler_kwargs"):

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -298,8 +298,8 @@ class _ModelTrainingConfig:
     save_model_checkpoints: bool = False
     model_path: str = ""
     timesteps_source: str = "timesteps_file"
-    derived_output_variables: List[str] = None
-    nonfeature_input_variables: List[str] = None
+    derived_output_variables: List[str] = dataclasses.field(default_factory=list)
+    nonfeature_input_variables: List[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self):
         if self.scaler_type == "mass":

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -69,6 +69,9 @@ class TrainingConfig:
         sample_dim_name: deprecated, internal name used for sample dimension
             when training and predicting
         random_seed: value to use to initialize randomness
+        derived_output_variables: optional list of prediction variables that
+            are not directly predicted by the ML model but instead are derived
+            using the ML-predicted output_variables
     """
 
     model_type: str

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -77,8 +77,8 @@ class TrainingConfig:
     hyperparameters: Dataclass
     sample_dim_name: str = "sample"
     random_seed: Union[float, int] = 0
-    derived_output_variables: List[str] = None
-    nonfeature_input_variables: List[str] = None
+    derived_output_variables: List[str] = dataclasses.field(default_factory=list)
+    nonfeature_input_variables: List[str] = dataclasses.field(default_factory=list)
 
     @classmethod
     def from_dict(cls, kwargs) -> "TrainingConfig":

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -77,6 +77,8 @@ class TrainingConfig:
     hyperparameters: Dataclass
     sample_dim_name: str = "sample"
     random_seed: Union[float, int] = 0
+    derived_output_variables: List[str] = None
+    nonfeature_input_variables: List[str] = None
 
     @classmethod
     def from_dict(cls, kwargs) -> "TrainingConfig":
@@ -296,6 +298,8 @@ class _ModelTrainingConfig:
     save_model_checkpoints: bool = False
     model_path: str = ""
     timesteps_source: str = "timesteps_file"
+    derived_output_variables: List[str] = None
+    nonfeature_input_variables: List[str] = None
 
     def __post_init__(self):
         if self.scaler_type == "mass":
@@ -328,6 +332,8 @@ def legacy_config_to_new_config(legacy_config: _ModelTrainingConfig) -> Training
         "output_variables",
         "random_seed",
         "sample_dim_name",
+        "derived_output_variables",
+        "nonfeature_input_variables",
     ]
     if config_class is RandomForestHyperparameters:
         for key in ("scaler_type", "scaler_kwargs"):

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -67,7 +67,6 @@ class DerivedModel(Predictor):
     def dump(self, path: str):
         base_model_path = os.path.join(path, self._BASE_MODEL_SUBDIR)
         options = {
-            "additional_input_variables": self._additional_input_variables,
             "derived_output_variables": self._derived_output_variables,
             "model": base_model_path,
         }

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -70,7 +70,7 @@ class DerivedModel(Predictor):
             "derived_output_variables": self._derived_output_variables,
             "model": base_model_path,
         }
-        self._base_model.dump(base_model_path)
+        io.dump(self._base_model, base_model_path)
         with fsspec.open(os.path.join(path, self._CONFIG_FILENAME), "w") as f:
             yaml.safe_dump(options, f)
 
@@ -105,7 +105,6 @@ class DerivedModel(Predictor):
             )
 
     def _check_derived_predictions_supported(self):
-
         invalid_derived_variables = np.setdiff1d(
             self._derived_output_variables, list(vcm.DerivedMapping.VARIABLES)
         )

--- a/external/fv3fit/fv3fit/_shared/models.py
+++ b/external/fv3fit/fv3fit/_shared/models.py
@@ -86,9 +86,10 @@ class DerivedModel(Predictor):
     def _get_additional_input_variables(self, derived_output_variables):
         additional_input_variables = []
         for derived_var in derived_output_variables:
-            additional_input_variables += vcm.DerivedMapping.REQUIRED_INPUTS[
-                derived_var
-            ]
+            if derived_var in vcm.DerivedMapping.REQUIRED_INPUTS:
+                additional_input_variables += vcm.DerivedMapping.REQUIRED_INPUTS[
+                    derived_var
+                ]
         return additional_input_variables
 
     def _check_additional_inputs_present(self, X: xr.Dataset):

--- a/external/fv3fit/fv3fit/testing.py
+++ b/external/fv3fit/fv3fit/testing.py
@@ -76,7 +76,6 @@ class ConstantOutputPredictor(Predictor):
         return xr.Dataset(data_vars=data_vars, coords=coords)
 
     def dump(self, path: str) -> None:
-        print("at dump, outputs: ", self._outputs)
         np.savez(os.path.join(path, "_outputs.npz"), **self._outputs)
         with open(os.path.join(path, "attrs.yaml"), "w") as f:
             yaml.safe_dump(

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -105,7 +105,7 @@ def main(args):
         train_batches=train_batches,
         validation_batches=val_batches,
     )
-    if train_config.derived_output_variables:
+    if len(train_config.derived_output_variables) > 0:
         model = DerivedModel(
             model,
             train_config.nonfeature_input_variables,

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -106,11 +106,7 @@ def main(args):
         validation_batches=val_batches,
     )
     if len(train_config.derived_output_variables) > 0:
-        model = DerivedModel(
-            model,
-            train_config.nonfeature_input_variables,
-            train_config.derived_output_variables,
-        )
+        model = DerivedModel(model, train_config.derived_output_variables,)
     io.dump(model, args.output_data_path)
 
 

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -7,7 +7,7 @@ import yaml
 import dataclasses
 import fsspec
 
-from fv3fit._shared import parse_data_path, load_data_sequence, io
+from fv3fit._shared import parse_data_path, load_data_sequence, io, DerivedModel
 import fv3fit._shared.config
 import fv3fit.keras
 import fv3fit.sklearn
@@ -105,6 +105,12 @@ def main(args):
         train_batches=train_batches,
         validation_batches=val_batches,
     )
+    if train_config.derived_output_variables:
+        model = DerivedModel(
+            model,
+            train_config.nonfeature_input_variables,
+            train_config.derived_output_variables,
+        )
     io.dump(model, args.output_data_path)
 
 

--- a/external/fv3fit/tests/test_derived_model.py
+++ b/external/fv3fit/tests/test_derived_model.py
@@ -20,11 +20,18 @@ base_model.set_outputs(
 )
 
 
+def test_get_additional_inputs():
+    derived_model = DerivedModel(
+        base_model, derived_output_variables=["net_shortwave_sfc_flux_derived"],
+    )
+    assert (
+        "surface_diffused_shortwave_albedo" in derived_model._additional_input_variables
+    )
+
+
 def test_derived_prediction():
     derived_model = DerivedModel(
-        base_model,
-        additional_input_variables=["surface_diffused_shortwave_albedo"],
-        derived_output_variables=["net_shortwave_sfc_flux_derived"],
+        base_model, derived_output_variables=["net_shortwave_sfc_flux_derived"],
     )
     ds_in = xr.Dataset(
         data_vars={
@@ -40,9 +47,7 @@ def test_derived_prediction():
 
 def test_derived_alert_to_missing_additional_input():
     derived_model = DerivedModel(
-        base_model,
-        additional_input_variables=["surface_diffused_shortwave_albedo"],
-        derived_output_variables=["net_shortwave_sfc_flux_derived"],
+        base_model, derived_output_variables=["net_shortwave_sfc_flux_derived"],
     )
     ds_in = xr.Dataset(
         data_vars={"input": xr.DataArray(np.zeros([3, 3, 5]), dims=["x", "y", "z"])}
@@ -54,7 +59,5 @@ def test_derived_alert_to_missing_additional_input():
 def test_invalid_derived_output_variables():
     with pytest.raises(ValueError):
         DerivedModel(
-            base_model,
-            additional_input_variables=["surface_diffused_shortwave_albedo"],
-            derived_output_variables=["variable_not_in_DerivedMapping"],
+            base_model, derived_output_variables=["variable_not_in_DerivedMapping"],
         )

--- a/external/fv3fit/tests/test_derived_model.py
+++ b/external/fv3fit/tests/test_derived_model.py
@@ -82,6 +82,4 @@ def test_dump_and_load(tmpdir):
     loaded_model = fv3fit.load(str(tmpdir))
 
     prediction_after_load = loaded_model.predict(input_data)
-    for var in loaded_model.output_variables:
-        assert var in derived_model.output_variables
-        assert np.allclose(prediction[var].values, prediction_after_load[var].values)
+    assert prediction_after_load.identical(prediction)

--- a/external/vcm/tests/test_derived_mapping.py
+++ b/external/vcm/tests/test_derived_mapping.py
@@ -146,3 +146,11 @@ def test_net_downward_shortwave_sfc_flux_derived():
     derived_state = DerivedMapping(ds)
     derived_net_sw = derived_state["net_shortwave_sfc_flux_derived"]
     np.testing.assert_array_almost_equal(derived_net_sw, [1.0, 0.5, 0.0])
+
+
+def test_required_inputs():
+    @DerivedMapping.register("test_derived_var", required_inputs=["required_input"])
+    def test_derived_var(self):
+        return None
+
+    assert set(DerivedMapping.REQUIRED_INPUTS["test_derived_var"]) == {"required_input"}


### PR DESCRIPTION
The previous PR to add the `DerivedModel` class did not include a dump method; it relied on the user manually creating the DerivedModel's save directory and yaml. This PR adds a dump method and config entry`derived_output_variables` to the `TrainingConfig`. If any `derived_output_variables` are specified in the config, the training script will wrap the trained ML model as a DerivedModel before saving. The `DerivedModel` will check to see if any additional input variables need to be added to its `input_variables` on top of the ML features to derive these variables.

Added the option to register a list of  `required_input_variables` to derived variables in `vcm.DerivedMapping`. The `DerivedModel` checks against these to see if it requires additional input variables to be present in the dataset used as input to its predict method on top of what is used as the base ML feature set. 

Added public API:
- optional config arg `TrainingConfig.derived_output_variables`. This has also been added to the legacy `_ModelTrainingConfig` since it's still being used.
