### PR TITLE
vcm.DerivedMapping: add one-hot encoding for sea/land/seaice sfc types

### DIFF
--- a/external/vcm/tests/test_derived_mapping.py
+++ b/external/vcm/tests/test_derived_mapping.py
@@ -154,3 +154,21 @@ def test_required_inputs():
         return None
 
     assert set(DerivedMapping.REQUIRED_INPUTS["test_derived_var"]) == {"required_input"}
+
+
+ds_sfc = xr.Dataset({"land_sea_mask": xr.DataArray([0, 1, 2], dims=["x"])})
+
+
+def test_is_sea():
+    derived_state = DerivedMapping(ds_sfc)
+    np.testing.assert_array_almost_equal(derived_state["is_sea"], [1.0, 0.0, 0.0])
+
+
+def test_is_land():
+    derived_state = DerivedMapping(ds_sfc)
+    np.testing.assert_array_almost_equal(derived_state["is_land"], [0.0, 1.0, 0.0])
+
+
+def test_is_sea_ice():
+    derived_state = DerivedMapping(ds_sfc)
+    np.testing.assert_array_almost_equal(derived_state["is_sea_ice"], [0.0, 0.0, 1.0])

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -151,3 +151,27 @@ def net_shortwave_sfc_flux_derived(self):
         "override_for_time_adjusted_total_sky_downward_shortwave_flux_at_surface"
     ]
     return (1 - albedo) * downward_sfc_shortwave_flux
+
+
+@DerivedMapping.register(
+    "is_land", required_inputs=["land_sea_mask"],
+)
+def is_land(self):
+    # one hot encoding for land / (sea or sea ice) surface
+    return xr.where(self["land_sea_mask"] == 1, 1.0, 0.0)
+
+
+@DerivedMapping.register(
+    "is_sea", required_inputs=["land_sea_mask"],
+)
+def is_sea(self):
+    # one hot encoding for sea surface
+    return xr.where(self["land_sea_mask"] == 0, 1.0, 0.0)
+
+
+@DerivedMapping.register(
+    "is_sea_ice", required_inputs=["land_sea_mask"],
+)
+def is_sea_ice(self):
+    # one hot encoding for sea ice surface
+    return xr.where(self["land_sea_mask"] == 2, 1.0, 0.0)

--- a/external/vcm/vcm/derived_mapping.py
+++ b/external/vcm/vcm/derived_mapping.py
@@ -158,7 +158,7 @@ def net_shortwave_sfc_flux_derived(self):
 )
 def is_land(self):
     # one hot encoding for land / (sea or sea ice) surface
-    return xr.where(self["land_sea_mask"] == 1, 1.0, 0.0)
+    return xr.where(vcm.xarray_utils.isclose(self["land_sea_mask"], 1), 1.0, 0.0)
 
 
 @DerivedMapping.register(
@@ -166,7 +166,7 @@ def is_land(self):
 )
 def is_sea(self):
     # one hot encoding for sea surface
-    return xr.where(self["land_sea_mask"] == 0, 1.0, 0.0)
+    return xr.where(vcm.xarray_utils.isclose(self["land_sea_mask"], 0), 1.0, 0.0)
 
 
 @DerivedMapping.register(
@@ -174,4 +174,4 @@ def is_sea(self):
 )
 def is_sea_ice(self):
     # one hot encoding for sea ice surface
-    return xr.where(self["land_sea_mask"] == 2, 1.0, 0.0)
+    return xr.where(vcm.xarray_utils.isclose(self["land_sea_mask"], 2), 1.0, 0.0)


### PR DESCRIPTION
This adds derived variables in `vcm.DerivedMapping` for sea / land / sea ice surfaces. Currently the neural networks only use `sfc_geopotential` as a proxy for surface type since the surface type information is contained in the 0/1/2 categorical variable `land_sea_mask`.

- [x] Tests added
