### PR TITLE
remove unused argument, add report to local installed packages

### DIFF
--- a/.environment-scripts/install_local_packages.sh
+++ b/.environment-scripts/install_local_packages.sh
@@ -31,6 +31,7 @@ poetry_packages=(
   external/synth
   external/fv3kube
   external/diagnostics_utils
+  external/report
   workflows/fine_res_budget
   workflows/offline_ml_diags
   workflows/dataflow

--- a/external/diagnostics_utils/diagnostics_utils/utils.py
+++ b/external/diagnostics_utils/diagnostics_utils/utils.py
@@ -39,7 +39,6 @@ def reduce_to_diagnostic(
     primary_vars: Sequence[str] = PRIMARY_VARS,
     net_precipitation: xr.DataArray = None,
     time_dim: str = "time",
-    derivation_dim: str = "derivation",
     uninformative_coords: Sequence[str] = ["tile", "z", "y", "x"],
 ) -> xr.Dataset:
     """Reduce a sequence of batches to a diagnostic dataset
@@ -57,8 +56,6 @@ def reduce_to_diagnostic(
             composites, typically supplied by SHiELD net_precipitation; optional
         time_dim: name of the dataset time dimension to average over; optional,
             defaults to 'time'
-        derivation_dim: name of the dataset derivation dimension containing coords
-            such as 'target', 'predict', etc.; optional, defaults to 'derivation'
         uninformative_coords: sequence of names of uninformative (i.e.,
             range(len(dim))), coordinates to be dropped
             


### PR DESCRIPTION
This PR removes an unused argument `derivation_dim` from an internal utility function, and adds `report` to packages installed by `make install_local_packages`.

You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
