### PR TITLE
add more validation safety to loaders, CLI tool for validation

### DIFF
--- a/external/loaders/docs/loaders_api.rst
+++ b/external/loaders/docs/loaders_api.rst
@@ -30,6 +30,19 @@ The second type can be initialized using the :py:class:`loaders.BatchesFromMappe
 
 The functions themselves take a ``data_path`` argument, followed by the keyword arguments in their API documentation below.
 
+Configuration files for batches data can be validated using a command-line tool ``validate_batches_config`` provided by this package. If the configuration is valid, it will exit without error. Note this only checks for type validation of the configuration entries, and does not test that the data referenced actually exists and is without errors.
+
+.. code-block:: bash
+
+   $ validate_batches_config --help
+   usage: validate_batches_config [-h] config
+
+   positional arguments:
+   config      path of BatchesLoader configuration yaml file
+
+   optional arguments:
+   -h, --help  show this help message and exit
+
 .. automodule:: loaders
    :imported-members:
    :members:

--- a/external/loaders/loaders/__init__.py
+++ b/external/loaders/loaders/__init__.py
@@ -31,4 +31,5 @@ from loaders.mappers import (
     open_nudge_to_fine_multiple_datasets,
     open_fine_resolution_nudging_hybrid,
     open_high_res_diags,
+    open_zarr,
 )

--- a/external/loaders/loaders/_config.py
+++ b/external/loaders/loaders/_config.py
@@ -48,6 +48,13 @@ class MapperConfig:
         mapping_func = mapper_functions[self.mapper_function]
         return mapping_func(self.data_path, **self.mapper_kwargs)
 
+    def __post_init__(self):
+        if self.mapper_function not in mapper_functions:
+            raise ValueError(
+                f"Invalid batches function {self.mapper_function}, "
+                f"must be one of {list(mapper_functions.keys())}"
+            )
+
 
 class BatchesLoader(abc.ABC):
     @abc.abstractmethod
@@ -105,6 +112,13 @@ class BatchesFromMapperConfig(BatchesLoader):
         batches_function = batches_from_mapper_functions[self.batches_function]
         return batches_function(mapper, list(variables), **self.batches_kwargs,)
 
+    def __post_init__(self):
+        if self.batches_function not in batches_from_mapper_functions:
+            raise ValueError(
+                f"Invalid batches function {self.batches_function}, "
+                f"must be one of {list(batches_from_mapper_functions.keys())}"
+            )
+
 
 @dataclasses.dataclass
 class BatchesConfig(BatchesLoader):
@@ -131,3 +145,10 @@ class BatchesConfig(BatchesLoader):
         """
         batches_function = batches_functions[self.batches_function]
         return batches_function(self.data_path, list(variables), **self.batches_kwargs,)
+
+    def __post_init__(self):
+        if self.batches_function not in batches_functions:
+            raise ValueError(
+                f"Invalid batches function {self.batches_function}, "
+                f"must be one of {list(batches_functions.keys())}"
+            )

--- a/external/loaders/loaders/_config.py
+++ b/external/loaders/loaders/_config.py
@@ -51,7 +51,7 @@ class MapperConfig:
     def __post_init__(self):
         if self.mapper_function not in mapper_functions:
             raise ValueError(
-                f"Invalid batches function {self.mapper_function}, "
+                f"Invalid mapper function {self.mapper_function}, "
                 f"must be one of {list(mapper_functions.keys())}"
             )
 

--- a/external/loaders/loaders/mappers/_fine_resolution_budget.py
+++ b/external/loaders/loaders/mappers/_fine_resolution_budget.py
@@ -423,8 +423,6 @@ def open_fine_res_apparent_sources(
             "20160801.000730", a value off 450 will shift this forward 7:30
             minutes, so that this same value can be accessed with the key
             "20160801.001500"
-        rename_vars: (mapping): optional mapping of variables to rename in dataset
-        drop_vars (sequence): optional list of variable names to drop from dataset
     """
 
     rename_vars: Mapping[Hashable, Hashable] = {
@@ -434,7 +432,7 @@ def open_fine_res_apparent_sources(
         "delp": "pressure_thickness_of_atmospheric_layer",
     }
     dim_order = ("tile", "z", "y", "x")
-    drop_vars = ("step", "time")
+    drop_vars = ("step",)
 
     fine_resolution_sources_mapper = FineResolutionSources(
         open_fine_resolution_budget(data_path),

--- a/external/loaders/loaders/mappers/_xarray.py
+++ b/external/loaders/loaders/mappers/_xarray.py
@@ -2,6 +2,7 @@ import xarray as xr
 import fsspec
 import vcm
 from ._base import GeoMapper
+from loaders._config import mapper_functions
 
 
 class XarrayMapper(GeoMapper):
@@ -49,6 +50,7 @@ class XarrayMapper(GeoMapper):
         return self.time_lookup.keys()
 
 
+@mapper_functions.register
 def open_zarr(url: str, consolidated: bool = True, dim: str = "time") -> XarrayMapper:
     ds = xr.open_zarr(fsspec.get_mapper(url), consolidated=consolidated)
     return XarrayMapper(ds, dim)

--- a/external/loaders/loaders/validate_batches_config.py
+++ b/external/loaders/loaders/validate_batches_config.py
@@ -1,0 +1,18 @@
+import loaders
+import argparse
+import yaml
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "config", type=str, help="path of BatchesLoader configuration yaml file",
+    )
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    with open(args.config, "r") as f:
+        loaders.BatchesLoader.from_dict(yaml.safe_load(f))

--- a/external/loaders/setup.py
+++ b/external/loaders/setup.py
@@ -10,6 +10,11 @@ setup(
     packages=find_packages(),
     package_dir={"": "."},
     package_data={},
+    entry_points={
+        "console_scripts": [
+            "validate_batches_config=loaders.validate_batches_config:main",
+        ]
+    },
     install_requires=[
         "fsspec>=0.7.4",
         "numpy>=1.18.4",


### PR DESCRIPTION
This PR adds some additional safety for loaders configuration, and a command-line tool to validate BatchesLoader configuration files.

Added public API:
- Added `validate_batches_config` command-line validation tool, which identifies formatting errors in BatchesLoader configuration files.
- Added `open_zarr` to registered mapper functions, and to top-level of loaders namespace
- Added post-init checks to loaders configuration classes which raise exceptions if invalid functions are used, instead of waiting until you attempt to load the data

Refactors of public API:
- fine res budget mapper no longer drops "time" from the dataset

Significant internal changes:
- Fixed bug in loaders tests where an error in a test would cause the context to fail to reset

- [x] Tests added

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
