### PR TITLE
Fix emulation function "get_nc_files"

### DIFF
--- a/external/fv3fit/fv3fit/emulation/data/io.py
+++ b/external/fv3fit/fv3fit/emulation/data/io.py
@@ -1,10 +1,11 @@
 import os
+import fsspec
 from typing import List
 
 from vcm import get_fs
 
 
-def get_nc_files(path: str) -> List[str]:
+def get_nc_files(path: str, fs: fsspec.AbstractFileSystem = None) -> List[str]:
     """
     Get a list of netCDF files from a remote/local directory
 
@@ -12,7 +13,14 @@ def get_nc_files(path: str) -> List[str]:
         path: Local or remote gcs path to netCDF directory
     """
 
-    fs = get_fs(path)
+    if fs is None:
+        fs = get_fs(path)
+
     files = list(fs.glob(os.path.join(path, "*.nc")))
+
+    # we want to preserve information about the remote protocol
+    # so any downstream operations can glean that info from the paths
+    if "gs" in fs.protocol:
+        files = ["gs://" + f for f in files]
 
     return files

--- a/external/fv3fit/fv3fit/emulation/data/io.py
+++ b/external/fv3fit/fv3fit/emulation/data/io.py
@@ -11,6 +11,8 @@ def get_nc_files(path: str, fs: fsspec.AbstractFileSystem = None) -> List[str]:
 
     Args:
         path: Local or remote gcs path to netCDF directory
+        fs: Filesystem object to use for the glob operation
+            searching for netCDFs in the path
     """
 
     if fs is None:

--- a/external/fv3fit/fv3fit/emulation/data/io.py
+++ b/external/fv3fit/fv3fit/emulation/data/io.py
@@ -1,11 +1,13 @@
 import os
 import fsspec
-from typing import List
+from typing import List, Optional
 
 from vcm import get_fs
 
 
-def get_nc_files(path: str, fs: fsspec.AbstractFileSystem = None) -> List[str]:
+def get_nc_files(
+    path: str, fs: Optional[fsspec.AbstractFileSystem] = None
+) -> List[str]:
     """
     Get a list of netCDF files from a remote/local directory
 

--- a/external/fv3fit/tests/emulation/test_data_io.py
+++ b/external/fv3fit/tests/emulation/test_data_io.py
@@ -48,7 +48,6 @@ class MockGCSFilesystem:
         ]
 
 
-@pytest.mark.network
 def test_get_nc_files_remote_protocol_prepend():
 
     fs = MockGCSFilesystem()

--- a/external/fv3fit/tests/emulation/test_data_io.py
+++ b/external/fv3fit/tests/emulation/test_data_io.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import tempfile
 import numpy as np

--- a/external/fv3fit/tests/emulation/test_data_io.py
+++ b/external/fv3fit/tests/emulation/test_data_io.py
@@ -37,7 +37,7 @@ def test_get_nc_files():
             assert path in orig_paths
 
 
-class MockFilesystem:
+class MockGCSFilesystem:
 
     protocol = ("gs", "gcs")
 
@@ -51,7 +51,7 @@ class MockFilesystem:
 @pytest.mark.network
 def test_get_nc_files_remote_protocol_prepend():
 
-    fs = MockFilesystem()
+    fs = MockGCSFilesystem()
     result_files = io.get_nc_files("gs://fake-bucket", fs=fs)
 
     assert len(result_files) == 2

--- a/external/fv3fit/tests/emulation/test_data_io.py
+++ b/external/fv3fit/tests/emulation/test_data_io.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 import tempfile
 import numpy as np
@@ -6,9 +7,9 @@ import xarray as xr
 from fv3fit.emulation.data import io
 
 
-def test_get_nc_files():
+def _get_ds():
 
-    xr_dataset = xr.Dataset(
+    return xr.Dataset(
         {
             "air_temperature": xr.DataArray(
                 data=np.arange(30).reshape(10, 3), dims=["sample", "z"]
@@ -19,13 +20,40 @@ def test_get_nc_files():
         }
     )
 
+
+def test_get_nc_files():
+
+    xr_dataset = _get_ds()
+
     with tempfile.TemporaryDirectory() as tmpdir:
         num_files = 3
-        paths = [os.path.join(tmpdir, f"file{i}.nc") for i in range(num_files)]
-        for path in paths:
+        orig_paths = [os.path.join(tmpdir, f"file{i}.nc") for i in range(num_files)]
+        for path in orig_paths:
             xr_dataset.to_netcdf(path)
 
         result_files = io.get_nc_files(tmpdir)
         assert len(result_files) == num_files
-        for path in paths:
-            assert path in result_files
+        for path in result_files:
+            assert path in orig_paths
+
+
+class MockFilesystem:
+
+    protocol = ("gs", "gcs")
+
+    def glob(*args):
+        return [
+            "fake-bucket/file1.nc",
+            "fake-bucket/file2.nc",
+        ]
+
+
+@pytest.mark.network
+def test_get_nc_files_remote_protocol_prepend():
+
+    fs = MockFilesystem()
+    result_files = io.get_nc_files("gs://fake-bucket", fs=fs)
+
+    assert len(result_files) == 2
+    for path in result_files:
+        assert path.startswith("gs://")


### PR DESCRIPTION
There was a bug i noticed when using `nc_dir_to_tf_dataset` that stems from a problem with `get_nc_files`.  

If provided with a path to a GCS directory of netCDF paths, the `get_nc_files` function used the `glob` method of a filesystem object, which would strip the protocol (`gs://`) from the list of files.  The removal of this information breaks the loading of the remote netCDF downstream because we a) don't provide initiated filesystem objects (gets messy fast) and b) without any protocol info in the path `get_remote_nc` thinks the file is local.  I adjusted `get_nc_files` to keep the path if it detects a GCS protocol for now.

- [x] Test added