### PR TITLE
Ensure output of rotate_xy_winds has same dim order as input

### DIFF
--- a/external/vcm/tests/test__rotate.py
+++ b/external/vcm/tests/test__rotate.py
@@ -6,8 +6,12 @@ from vcm.cubedsphere.rotate import rotate_xy_winds
 
 def test_eastnorth_wind_tendencies():
     cell_centered_array = xr.DataArray(
-        [[1.0]], dims=["x", "y"], coords={"x": [0], "y": [0]}
+        [[[1.0]], [[1.0]]],
+        dims=["time", "x", "y"],
+        coords={"time": [3, 4], "x": [0], "y": [0]},
     )
+    expected_eastward_wind = xr.full_like(cell_centered_array, np.sqrt(2.0))
+    expected_northward_wind = xr.full_like(cell_centered_array, 0.0)
     # lat/lon axes 45 deg rotated from x/y
     wind_rotation_matrix = xr.Dataset(
         {
@@ -25,8 +29,8 @@ def test_eastnorth_wind_tendencies():
             ),
         }
     )
-    result = rotate_xy_winds(
+    eastward_wind, northward_wind = rotate_xy_winds(
         wind_rotation_matrix, cell_centered_array, cell_centered_array
     )
-    assert result[0] == [np.sqrt(2.0)]
-    assert result[1] == [0.0]
+    xr.testing.assert_identical(eastward_wind, expected_eastward_wind)
+    xr.testing.assert_identical(northward_wind, expected_northward_wind)

--- a/external/vcm/vcm/cubedsphere/rotate.py
+++ b/external/vcm/vcm/cubedsphere/rotate.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import xarray as xr
 from .coarsen import shift_edge_var_to_center
 
@@ -8,7 +10,7 @@ def center_and_rotate_xy_winds(
     wind_rotation_matrix: xr.Dataset,
     x_component: xr.DataArray,
     y_component: xr.DataArray,
-):
+) -> Tuple[xr.DataArray, xr.DataArray]:
     """ Transform D grid x/y winds to A grid E/N winds.
 
     Args:
@@ -16,6 +18,9 @@ def center_and_rotate_xy_winds(
         x/y to E/N rotation. Can be found in catalog.
         x_component : D grid x wind
         y_component : D grid y wind
+
+    Returns:
+        Tuple of eastward and northward winds on A-grid.
     """
     common_coords = {
         "x": wind_rotation_matrix["x"].values,
@@ -34,15 +39,18 @@ def center_and_rotate_xy_winds(
 
 def rotate_xy_winds(
     wind_rotation_matrix: xr.Dataset,
-    x_component: xr.DataArray,
-    y_component: xr.DataArray,
-):
+    x_wind_centered: xr.DataArray,
+    y_wind_centered: xr.DataArray,
+) -> Tuple[xr.DataArray, xr.DataArray]:
     eastward = (
-        wind_rotation_matrix["eastward_wind_u_coeff"] * x_component
-        + wind_rotation_matrix["eastward_wind_v_coeff"] * y_component
+        wind_rotation_matrix["eastward_wind_u_coeff"] * x_wind_centered
+        + wind_rotation_matrix["eastward_wind_v_coeff"] * y_wind_centered
     )
     northward = (
-        wind_rotation_matrix["northward_wind_u_coeff"] * x_component
-        + wind_rotation_matrix["northward_wind_v_coeff"] * y_component
+        wind_rotation_matrix["northward_wind_u_coeff"] * x_wind_centered
+        + wind_rotation_matrix["northward_wind_v_coeff"] * y_wind_centered
     )
-    return eastward, northward
+    return (
+        eastward.transpose(*x_wind_centered.dims),
+        northward.transpose(*y_wind_centered.dims),
+    )


### PR DESCRIPTION
With this fix, the `dQu` and `dQv` predicted by nudge-to-fine models should have same dimension order as other variables.

- [x] Tests added

Resolves #1312 