### PR TITLE
Fix typo in e2e configuration

### DIFF
--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -105,7 +105,7 @@ spec:
                 - net_moistening_due_to_nudging
                 - column_heating_due_to_nudging
                 - net_mass_tendency_due_to_nudging
-                - total_precipation_rate
+                - total_precipitation_rate
                 - water_vapor_path
                 - physics_precip
             - name: nudging_tendencies.zarr


### PR DESCRIPTION
I launched the e2e test locally and it passed.