### PR TITLE
Simplify hybrid mapper function

### DIFF
--- a/external/loaders/loaders/mappers/_hybrid.py
+++ b/external/loaders/loaders/mappers/_hybrid.py
@@ -1,6 +1,3 @@
-from typing import Any
-
-
 import fsspec
 import xarray
 import numpy
@@ -195,14 +192,12 @@ def open_fine_resolution_nudging_hybrid_dataset(
 
 @mapper_functions.register
 def open_fine_resolution_nudging_hybrid(
-    _: Any, fine_url: str = "", nudge_url: str = ""
+    fine_url: str = "", nudge_url: str = ""
 ) -> GeoMapper:
     """
     Open the fine resolution nudging_hybrid mapper
 
     Args:
-        _: the loading infrastructure expects this argument, but it is not used
-            by the hybrid sheme. Keep this in mind when configuring
         fine_url: url where coarsened fine resolution data is stored
         nudge_url: url to nudging data to be used as a residual
 

--- a/external/loaders/loaders/mappers/_xarray.py
+++ b/external/loaders/loaders/mappers/_xarray.py
@@ -37,14 +37,15 @@ class XarrayMapper(GeoMapper):
 
         """
         self.data = data
+        self._time_name = time
 
-        times = self.data.time.values.tolist()
+        times = self.data[self._time_name].values.tolist()
         time_strings = [vcm.encode_time(time) for time in times]
         self.time_lookup = dict(zip(time_strings, times))
         self.time_string_lookup = dict(zip(times, time_strings))
 
     def __getitem__(self, time_string):
-        return self.data.sel(time=self.time_lookup[time_string])
+        return self.data.sel({self._time_name: self.time_lookup[time_string]})
 
     def keys(self):
         return self.time_lookup.keys()
@@ -55,4 +56,4 @@ def open_zarr(
     data_path: str, consolidated: bool = True, dim: str = "time"
 ) -> XarrayMapper:
     ds = xr.open_zarr(fsspec.get_mapper(data_path), consolidated=consolidated)
-    return XarrayMapper(ds, dim)
+    return XarrayMapper(ds, time=dim)

--- a/external/loaders/tests/test__nudged.py
+++ b/external/loaders/tests/test__nudged.py
@@ -235,6 +235,6 @@ def test_open_fine_resolution_nudging_hybrid(
     regtest, nudge_to_fine_data_dir, fine_res_zarr
 ):
     data = open_fine_resolution_nudging_hybrid(
-        None, fine_url=fine_res_zarr, nudge_url=nudge_to_fine_data_dir,
+        fine_url=fine_res_zarr, nudge_url=nudge_to_fine_data_dir,
     )
     data[timestep1_end].info(regtest)

--- a/external/loaders/tests/test__xarray.py
+++ b/external/loaders/tests/test__xarray.py
@@ -2,6 +2,7 @@ import doctest
 import loaders.mappers._xarray
 import xarray as xr
 import numpy as np
+import pytest
 import cftime
 
 # ensure that imported path exists
@@ -12,15 +13,20 @@ def test_xarray_wrapper_doctests():
     doctest.testmod(loaders.mappers._xarray, raise_on_error=True)
 
 
-def test_open_zarr(tmpdir):
+@pytest.mark.parametrize(
+    "time_dim_name", ["another_name", "time"],
+)
+def test_open_zarr(tmpdir, time_dim_name):
     time = cftime.DatetimeJulian(2020, 1, 1)
     time_str = "20200101.000000"
     ds = xr.Dataset(
-        {"a": (["time", "tile", "z", "y", "x"], np.ones((1, 2, 3, 4, 5)))},
-        coords={"time": [time]},
+        {"a": ([time_dim_name, "tile", "z", "y", "x"], np.ones((1, 2, 3, 4, 5)))},
+        coords={time_dim_name: [time]},
     )
     ds.to_zarr(str(tmpdir), consolidated=True)
 
-    mapper = open_zarr(str(tmpdir))
+    mapper = open_zarr(str(tmpdir), dim=time_dim_name)
     assert isinstance(mapper, XarrayMapper)
-    xr.testing.assert_equal(mapper[time_str], ds.isel(time=0))
+    print(ds.isel({time_dim_name: 0}))
+    print(mapper)
+    xr.testing.assert_equal(mapper[time_str], ds.isel({time_dim_name: 0}))

--- a/external/loaders/tests/test__xarray.py
+++ b/external/loaders/tests/test__xarray.py
@@ -27,6 +27,4 @@ def test_open_zarr(tmpdir, time_dim_name):
 
     mapper = open_zarr(str(tmpdir), dim=time_dim_name)
     assert isinstance(mapper, XarrayMapper)
-    print(ds.isel({time_dim_name: 0}))
-    print(mapper)
     xr.testing.assert_equal(mapper[time_str], ds.isel({time_dim_name: 0}))


### PR DESCRIPTION
Since #1304, we no longer need to include a placeholder positional argument in `open_fine_resolution_nudging_hybrid`. This PR removes that argument to simplify configuration. It also fixes a bug in `XarrayMapper` in which the provided `time` argument was not used within the mapper.

- [x] Tests added