### PR TITLE
Increase default memory request for offline diags workflow

### DIFF
--- a/workflows/argo/offline-diags.yaml
+++ b/workflows/argo/offline-diags.yaml
@@ -24,7 +24,7 @@ spec:
           - name: validation_data_config
           - name: offline-diags-output
           - name: report-output
-          - {name: memory, value: 6Gi}
+          - {name: memory, value: 10Gi}
 
       container:
         image: us.gcr.io/vcm-ml/fv3net

--- a/workflows/argo/train-diags-prog.yaml
+++ b/workflows/argo/train-diags-prog.yaml
@@ -35,7 +35,7 @@ spec:
       - {name: cpu-prog, value: "6"}
       - {name: memory-prog, value: 6Gi}
       - {name: memory-training, value: 6Gi}
-      - {name: memory-offline-diags, value: 6Gi}
+      - {name: memory-offline-diags, value: 10Gi}
       - {name: training-flags, value: " "}
       - {name: online-diags-flags, value: " "}
     dag:


### PR DESCRIPTION
The offline diags fail with the default memory request (6Gi) even with a 'standard' ML model like a RF which predicts dQ1 and dQ2 and was trained on 130 timesteps worth of samples. These often leads to failures partway through the long-running train-diags-prog-run workflow. This PR increases the default request to 10Gi.