### PR TITLE
Coarsen restarts writes input dirs

### DIFF
--- a/external/fv3kube/fv3kube/__init__.py
+++ b/external/fv3kube/fv3kube/__init__.py
@@ -2,7 +2,6 @@ from .config import (
     update_tiled_asset_names,
     get_base_fv3config,
     get_full_config,
-    c48_initial_conditions_overlay,
     merge_fv3config_overlays,
 )
 from .utils import (

--- a/tests/end_to_end_integration/argo.yaml
+++ b/tests/end_to_end_integration/argo.yaml
@@ -5,15 +5,13 @@ metadata:
 spec:
   arguments:
     parameters:
-      - name: initial-condition
-        value: "20160801.001500"
-      - name: reference-restarts
-        value: gs://vcm-ml-code-testing-data/c48-restarts-for-e2e
       - name: nudge-to-fine-config
         value: | 
           base_version: v0.6
           forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
+          initial_conditions: gs://vcm-ml-code-testing-data/v2/c48-restarts-for-e2e/20160801.001500
           nudging:
+            restarts_path: gs://vcm-ml-code-testing-data/v2/c48-restarts-for-e2e/
             timescale_hours:
               air_temperature: 3
               specific_humidity: 3
@@ -22,13 +20,7 @@ spec:
               pressure_thickness_of_atmospheric_layer: 3
           namelist:
             coupler_nml:
-              current_date:
-                - 2016
-                - 8
-                - 1
-                - 0
-                - 15
-                - 0
+              current_date: [2016, 8, 1, 0, 15, 0]
               hours: 0
               minutes: 30
             fv_core_nml:
@@ -335,10 +327,6 @@ spec:
           template: prognostic-run
         arguments:
           parameters:
-          - name: reference-restarts
-            value: "{{workflow.parameters.reference-restarts}}"
-          - name: initial-condition
-            value: "{{workflow.parameters.initial-condition}}"
           - name: bucket
             value: "{{workflow.parameters.bucket}}"
           - name: project
@@ -374,12 +362,8 @@ spec:
             value: "{{workflow.parameters.training-data-config}}"
           - name: validation-data-config
             value: "{{workflow.parameters.validation-data-config}}"
-          - name: initial-condition
-            value: "{{workflow.parameters.initial-condition}}"
           - name: prognostic-run-config
             value: "{{workflow.parameters.prognostic-run-config}}"
-          - name: reference-restarts
-            value: "{{workflow.parameters.reference-restarts}}"
           - name: public-report-output
             value: "{{tasks.resolve-output-url.outputs.result}}/offline-report"
           - name: cpu-prog

--- a/workflows/argo/README.md
+++ b/workflows/argo/README.md
@@ -61,9 +61,7 @@ sequential segments.
 
 | Parameter            | Description                                                                   |
 |----------------------|-------------------------------------------------------------------------------|
-| `initial-condition`  | Timestamp string for time at which to begin the prognostic run                |
 | `config`             | String representation of base config YAML file; supplied to prepare-config |
-| `reference-restarts` | Location of restart data for initializing the prognostic run                  |
 | `tag`                | Tag which describes the run and is used in its storage location               | 
 | `flags`              | (optional) Extra command line flags for prepare-config                    |
 | `bucket`             | (optional) Bucket to save run output data; default 'vcm-ml-experiments'       |
@@ -87,8 +85,6 @@ And then calls:
 prepare-config \
         {{inputs.parameters.flags}} \
         {{inputs.parameters.config}} \
-        {{inputs.parameters.reference-restarts}} \
-        {{inputs.parameters.initial-condition}} \
         > /tmp/fv3config.yaml
 ```
 And then
@@ -254,9 +250,7 @@ the appropriate verification using the `online-diags-flags` parameter, e.g. `-p 
 | `train-times`           | `times` for `training` workflow                                       |
 | `test-times`            | `times` for `offline-diags` workflow                                  |
 | `public-report-output`  | `report-output` for `offline-diags` workflow                          |
-| `initial-condition`     | `initial-condition` for `prognostic-run` workflow                     |
 | `prognostic-run-config` | `config` for `prognostic-run` workflow                                |
-| `reference-restarts`    | `reference-restarts` for `prognostic-run` workflow                    |
 | `bucket`                | (optional) Bucket to save output data; default 'vcm-ml-experiments'   |
 | `project`               | (optional) Project directory to save output data; default 'default'   |
 | `flags`                 | (optional) `flags` for `prognostic-run` workflow                      |

--- a/workflows/argo/prognostic-run.yaml
+++ b/workflows/argo/prognostic-run.yaml
@@ -19,9 +19,7 @@ spec:
     - name: prognostic-run
       inputs:
         parameters:
-          - {name: initial-condition}
           - {name: config}
-          - {name: reference-restarts}
           - {name: tag}
           - {name: flags, value: ""}
           - {name: bucket, value: "vcm-ml-experiments"}
@@ -45,9 +43,7 @@ spec:
           template: prepare-config
           arguments:
             parameters:
-              - {name: initial-condition, value: "{{inputs.parameters.initial-condition}}"}
               - {name: config, value: "{{inputs.parameters.config}}"}
-              - {name: reference-restarts, value: "{{inputs.parameters.reference-restarts}}"}
               - {name: flags, value: "{{inputs.parameters.flags}}"}
       - - name: run-model
           continueOn:
@@ -95,9 +91,7 @@ spec:
     - name: prepare-config
       inputs:
         parameters:
-          - name: initial-condition
           - name: config
-          - name: reference-restarts
           - name: flags
       outputs:
         artifacts:
@@ -118,6 +112,4 @@ spec:
             prepare-config \
               {{inputs.parameters.flags}} \
               config.yaml \
-              {{inputs.parameters.reference-restarts}} \
-              {{inputs.parameters.initial-condition}} \
               > /tmp/fv3config.yaml

--- a/workflows/prognostic_c48_run/runtime/nudging.py
+++ b/workflows/prognostic_c48_run/runtime/nudging.py
@@ -122,7 +122,6 @@ def _get_reference_state(
     state = fv3gfs.util.open_restart(
         localdir,
         communicator,
-        label=label,
         only_names=only_names,
         tracer_properties=tracer_metadata,
     )

--- a/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
@@ -45,16 +45,6 @@ def _create_arg_parser() -> argparse.ArgumentParser:
         "fv3config (e.g. diag_table, runtime, ...) for the prognostic run.",
     )
     parser.add_argument(
-        "initial_condition_url",
-        type=str,
-        help="Remote url to directory holding timesteps with model initial conditions.",
-    )
-    parser.add_argument(
-        "ic_timestep",
-        type=str,
-        help="YYYYMMDD.HHMMSS timestamp to grab from the initial conditions url.",
-    )
-    parser.add_argument(
         "--model_url",
         type=str,
         default=None,


### PR DESCRIPTION
Simplify the prognostic run configuration workflow by saving the coarsened restart files in the naming convention expected by fv3gfs.