### PR TITLE
Use consistent colorbar limits in prognostic run report

### DIFF
--- a/external/fv3viz/docs/fv3viz_api.rst
+++ b/external/fv3viz/docs/fv3viz_api.rst
@@ -23,6 +23,6 @@ Timestep histogram plotting functions
 Utility functions
 -----------------
 .. automodule:: fv3viz
-   :members: auto_limits_cmap
+   :members: infer_cmap_params
    
    

--- a/external/fv3viz/docs/fv3viz_api.rst
+++ b/external/fv3viz/docs/fv3viz_api.rst
@@ -19,4 +19,10 @@ Timestep histogram plotting functions
 .. automodule:: fv3viz
    :members: plot_daily_and_hourly_hist, plot_daily_hist, plot_hourly_hist
    
+
+Utility functions
+-----------------
+.. automodule:: fv3viz
+   :members: auto_limits_cmap
+   
    

--- a/external/fv3viz/fv3viz/__init__.py
+++ b/external/fv3viz/fv3viz/__init__.py
@@ -9,7 +9,7 @@ from ._plot_diagnostics import (
     plot_diag_var_single_map,
     plot_time_series,
 )
-from ._plot_helpers import auto_limits_cmap
+from ._plot_helpers import infer_cmap_params
 
 __all__ = [
     "plot_daily_and_hourly_hist",
@@ -22,6 +22,7 @@ __all__ = [
     "plot_diurnal_cycle",
     "plot_diag_var_single_map",
     "plot_time_series",
+    "infer_cmap_params",
 ]
 
 __version__ = "0.1.0"

--- a/external/fv3viz/fv3viz/__init__.py
+++ b/external/fv3viz/fv3viz/__init__.py
@@ -9,6 +9,7 @@ from ._plot_diagnostics import (
     plot_diag_var_single_map,
     plot_time_series,
 )
+from ._plot_helpers import auto_limits_cmap
 
 __all__ = [
     "plot_daily_and_hourly_hist",

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -9,10 +9,9 @@ from ._constants import (
     VAR_LAT_OUTER,
 )
 from ._plot_helpers import (
-    _infer_color_limits,
+    auto_limits_cmap,
     _get_var_label,
     _remove_redundant_dims,
-    _min_max_from_percentiles,
 )
 from ._masking import _mask_antimeridian_quads
 import xarray as xr
@@ -124,15 +123,12 @@ def plot_cube(
     """
     var_name = list(plottable_variable.data_vars)[0]
     array = plottable_variable[var_name].values
-    if cmap_percentiles_lim:
-        xmin, xmax = _min_max_from_percentiles(array)
-    else:
-        xmin, xmax = np.nanmin(array), np.nanmax(array)
-    vmin = kwargs["vmin"] if "vmin" in kwargs else None
-    vmax = kwargs["vmax"] if "vmax" in kwargs else None
-    cmap = kwargs["cmap"] if "cmap" in kwargs else None
-    kwargs["vmin"], kwargs["vmax"], kwargs["cmap"] = _infer_color_limits(
-        xmin, xmax, vmin, vmax, cmap
+    kwargs["vmin"], kwargs["vmax"], kwargs["cmap"] = auto_limits_cmap(
+        array,
+        vmin=kwargs.get("vmin"),
+        vmax=kwargs.get("vmax"),
+        cmap=kwargs.get("cmap"),
+        robust=cmap_percentiles_lim,
     )
 
     _plot_func_short = partial(

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -9,7 +9,7 @@ from ._constants import (
     VAR_LAT_OUTER,
 )
 from ._plot_helpers import (
-    auto_limits_cmap,
+    infer_cmap_params,
     _get_var_label,
     _remove_redundant_dims,
 )
@@ -123,7 +123,7 @@ def plot_cube(
     """
     var_name = list(plottable_variable.data_vars)[0]
     array = plottable_variable[var_name].values
-    kwargs["vmin"], kwargs["vmax"], kwargs["cmap"] = auto_limits_cmap(
+    kwargs["vmin"], kwargs["vmax"], kwargs["cmap"] = infer_cmap_params(
         array,
         vmin=kwargs.get("vmin"),
         vmax=kwargs.get("vmax"),

--- a/external/fv3viz/fv3viz/_plot_helpers.py
+++ b/external/fv3viz/fv3viz/_plot_helpers.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 import textwrap
 
@@ -115,3 +117,30 @@ def _get_var_label(attrs: dict, var_name: str, max_line_length: int = 30):
     if "units" in attrs:
         var_label += f" [{attrs['units']}]"
     return "\n".join(textwrap.wrap(var_label, max_line_length))
+
+
+def auto_limits_cmap(
+    data: np.ndarray,
+    vmin: float = None,
+    vmax: float = None,
+    cmap: str = None,
+    robust: bool = False,
+) -> Tuple[float, float, str]:
+    """Determine useful colorbar limits and cmap for given data.
+    
+    Args:
+        data: The data to be plotted.
+        vmin: Optional minimum for colorbar.
+        vmax: Optional maximum for colorbar.
+        cmap: Optional colormap to use.
+        robust: If true, use 2nd and 98th percentiles for colorbar limits.
+
+    Returns:
+        Tuple of (vmin, vmax, cmap).
+    """
+    if robust:
+        xmin, xmax = _min_max_from_percentiles(data)
+    else:
+        xmin, xmax = np.nanmin(data), np.nanmax(data)
+    vmin, vmax, cmap = _infer_color_limits(xmin, xmax, vmin, vmax, cmap)
+    return vmin, vmax, cmap

--- a/external/fv3viz/fv3viz/_plot_helpers.py
+++ b/external/fv3viz/fv3viz/_plot_helpers.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import textwrap
@@ -119,11 +119,11 @@ def _get_var_label(attrs: dict, var_name: str, max_line_length: int = 30):
     return "\n".join(textwrap.wrap(var_label, max_line_length))
 
 
-def auto_limits_cmap(
+def infer_cmap_params(
     data: np.ndarray,
-    vmin: float = None,
-    vmax: float = None,
-    cmap: str = None,
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
+    cmap: Optional[str] = None,
     robust: bool = False,
 ) -> Tuple[float, float, str]:
     """Determine useful colorbar limits and cmap for given data.

--- a/external/fv3viz/tests/test_plot_helpers.py
+++ b/external/fv3viz/tests/test_plot_helpers.py
@@ -33,6 +33,6 @@ def test__get_var_label(attrs, var_name, expected_label):
         (np.array([-0.5, 0, 1]), {"vmin": -0.6}, (-0.6, 0.6, "RdBu_r")),
     ],
 )
-def test_auto_limits_cmap(data, args, expected_result):
-    result = fv3viz.auto_limits_cmap(data, **args)
+def test_infer_cmap_params(data, args, expected_result):
+    result = fv3viz.infer_cmap_params(data, **args)
     assert result == expected_result

--- a/external/fv3viz/tests/test_plot_helpers.py
+++ b/external/fv3viz/tests/test_plot_helpers.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+import fv3viz
+from fv3viz._plot_helpers import _get_var_label
+
+
+@pytest.mark.parametrize(
+    "attrs,var_name,expected_label",
+    [
+        ({}, "temp", "temp"),
+        ({"long_name": "air_temperature"}, "temp", "air_temperature"),
+        ({"units": "degK"}, "temp", "temp [degK]"),
+        (
+            {"long_name": "air_temperature", "units": "degK"},
+            "temp",
+            "air_temperature [degK]",
+        ),
+    ],
+)
+def test__get_var_label(attrs, var_name, expected_label):
+    assert _get_var_label(attrs, var_name) == expected_label
+
+
+@pytest.mark.parametrize(
+    "data, args, expected_result",
+    [
+        (np.array([0.0, 0.5, 1.0]), {}, (0.0, 1.0, "viridis")),
+        (np.array([-0.5, 0, 1]), {}, (-1.0, 1.0, "RdBu_r")),
+        (np.array([0.0, 0.5, 1.0]), {"robust": True}, (0.02, 0.98, "viridis")),
+        (np.array([0.0, 0.5, 1.0]), {"cmap": "jet"}, (0.0, 1.0, "jet")),
+        (np.array([0.0, 0.5, 1.0]), {"vmin": 0.2}, (0.2, 1.0, "viridis")),
+        (np.array([-0.5, 0, 1]), {"vmin": -0.6}, (-0.6, 0.6, "RdBu_r")),
+    ],
+)
+def test_auto_limits_cmap(data, args, expected_result):
+    result = fv3viz.auto_limits_cmap(data, **args)
+    assert result == expected_result

--- a/external/fv3viz/tests/test_visualize.py
+++ b/external/fv3viz/tests/test_visualize.py
@@ -312,6 +312,7 @@ def test_plot_cube_with_all_nans(sample_dataset, plotting_function):
         ax=ax,
     )
 
+
 example_timesteps = [
     [datetime(2016, 8, 1), datetime(2016, 8, 2)],
     (datetime(2016, 8, 1), datetime(2016, 8, 2)),

--- a/external/fv3viz/tests/test_visualize.py
+++ b/external/fv3viz/tests/test_visualize.py
@@ -12,7 +12,6 @@ from fv3viz._masking import (
     _periodic_difference,
 )
 from fv3viz._plot_cube import mappable_var, plot_cube_axes, plot_cube
-from fv3viz._plot_helpers import _get_var_label
 from fv3viz._timestep_histograms import (
     plot_daily_and_hourly_hist,
     plot_daily_hist,
@@ -312,24 +311,6 @@ def test_plot_cube_with_all_nans(sample_dataset, plotting_function):
         plotting_function=plotting_function,
         ax=ax,
     )
-
-
-@pytest.mark.parametrize(
-    "attrs,var_name,expected_label",
-    [
-        ({}, "temp", "temp"),
-        ({"long_name": "air_temperature"}, "temp", "air_temperature"),
-        ({"units": "degK"}, "temp", "temp [degK]"),
-        (
-            {"long_name": "air_temperature", "units": "degK"},
-            "temp",
-            "air_temperature [degK]",
-        ),
-    ],
-)
-def test__get_var_label(attrs, var_name, expected_label):
-    assert _get_var_label(attrs, var_name) == expected_label
-
 
 example_timesteps = [
     [datetime(2016, 8, 1), datetime(2016, 8, 2)],

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -93,7 +93,7 @@ def plot_2d_matplotlib(
 
     variables_to_plot = run_diags.matching_variables(varfilter)
     for varname in variables_to_plot:
-        plot_kwargs = _get_plot_kwargs(run_diags, varname, robust=False)
+        cmap_kwargs = _get_cmap_kwargs(run_diags, varname, robust=False)
         for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             v = run_diags.get_variable(run, varname)
@@ -105,7 +105,7 @@ def plot_2d_matplotlib(
                     v, ax=ax, x=x, y=y, levels=levels, extend="both", **opts
                 )
             else:
-                v.plot(ax=ax, x=x, y=y, **plot_kwargs, **opts)
+                v.plot(ax=ax, x=x, y=y, **cmap_kwargs, **opts)
             if ylabel:
                 ax.set_ylabel(ylabel)
             ax.set_title(long_name_and_units)
@@ -148,7 +148,7 @@ def plot_cubed_sphere_map(
 
     variables_to_plot = run_diags.matching_variables(varfilter)
     for varname in variables_to_plot:
-        plot_kwargs = _get_plot_kwargs(run_diags, varname, robust=True)
+        cmap_kwargs = _get_cmap_kwargs(run_diags, varname, robust=True)
         for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
@@ -160,7 +160,7 @@ def plot_cubed_sphere_map(
                 figsize=(6, 3), subplot_kw={"projection": ccrs.Robinson()}
             )
             mv = fv3viz.mappable_var(ds, varname, coord_vars=_COORD_VARS, **COORD_NAMES)
-            fv3viz.plot_cube(mv, ax=ax, **plot_kwargs)
+            fv3viz.plot_cube(mv, ax=ax, **cmap_kwargs)
             ax.set_title(plot_title)
             plt.subplots_adjust(left=0.01, right=0.75, bottom=0.02)
             data[varname][run] = fig_to_b64(fig)
@@ -207,10 +207,10 @@ def _render_map_title(
     return ", ".join(title_parts)
 
 
-def _get_plot_kwargs(run_diags, variable, robust=False, **kwargs):
+def _get_cmap_kwargs(run_diags, variable, robust=False):
     input_data = []
     for run in run_diags.runs:
         input_data.append(run_diags.get_variable(run, variable).assign_coords(run=run))
     input_data = xr.concat(input_data, dim="run")
-    plot_kwargs = _determine_cmap_params(input_data.values, robust=robust, **kwargs)
-    return {k: plot_kwargs[k] for k in ["vmin", "vmax", "cmap"]}
+    result = _determine_cmap_params(input_data.values, robust=robust)
+    return {k: result[k] for k in ["vmin", "vmax", "cmap"]}

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -92,9 +92,10 @@ def plot_2d_matplotlib(
 
     variables_to_plot = run_diags.matching_variables(varfilter)
     for varname in variables_to_plot:
-        opts["vmin"], opts["vmax"], opts["cmap"] = _get_cmap_kwargs(
-            run_diags, varname, robust=False
-        )
+        if not contour:
+            opts["vmin"], opts["vmax"], opts["cmap"] = _get_cmap_kwargs(
+                run_diags, varname, robust=False
+            )
         for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             v = run_diags.get_variable(run, varname)

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -2,8 +2,9 @@ import base64
 import io
 import logging
 from collections import defaultdict
-from typing import Sequence, Mapping
+from typing import Tuple, Mapping
 import xarray as xr
+from xarray.plot.utils import _determine_cmap_params
 
 import cartopy.crs as ccrs
 import jinja2
@@ -64,21 +65,20 @@ template = jinja2.Template(
 """
 )
 
-CBAR_RANGE = {
-    "eastward_wind_pressure_level_zonal_bias": 30,
-    "northward_wind_pressure_level_zonal_bias": 3,
-    "air_temperature_pressure_level_zonal_bias": 15,
-    "specific_humidity_pressure_level_zonal_bias": 1e-3,
-    "vertical_wind_pressure_level_zonal_bias": 0.02,
-    "mass_streamfunction_pressure_level_zonal_bias": 100,
+CONTOUR_LEVELS = {
+    "eastward_wind_pressure_level_zonal_bias": np.arange(-30, 31, 4),
+    "northward_wind_pressure_level_zonal_bias": np.arange(-3, 3.1, 0.4),
+    "air_temperature_pressure_level_zonal_bias": np.arange(-15, 16, 2),
+    "specific_humidity_pressure_level_zonal_bias": np.arange(-1.1e-3, 1.2e-3, 2e-4),
+    "vertical_wind_pressure_level_zonal_bias": np.arange(-2.1e-2, 2.1e-2, 2e-3),
+    "mass_streamfunction_pressure_level_zonal_bias": np.arange(-105, 106, 10),
 }
-CONTOUR_LEVELS = 20
 
 
 def plot_2d_matplotlib(
     run_diags: RunDiagnostics,
     varfilter: str,
-    dims: Sequence = None,
+    dims: Tuple[str, str],
     contour=False,
     **opts,
 ) -> RawHTML:
@@ -92,27 +92,20 @@ def plot_2d_matplotlib(
     x, y = dims
 
     variables_to_plot = run_diags.matching_variables(varfilter)
-    for run in run_diags.runs:
-        for varname in variables_to_plot:
-            vmax = CBAR_RANGE.get(varname)
+    for varname in variables_to_plot:
+        plot_kwargs = _get_plot_kwargs(run_diags, varname, robust=False)
+        for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             v = run_diags.get_variable(run, varname)
             long_name_and_units = f"{v.long_name} [{v.units}]"
             fig, ax = plt.subplots()
             if contour:
-                cbar_levels = np.arange(-vmax, vmax, step=2 * vmax / CONTOUR_LEVELS)
+                levels = CONTOUR_LEVELS.get(varname)
                 xr.plot.contourf(
-                    v,
-                    ax=ax,
-                    x=x,
-                    y=y,
-                    vmax=vmax,
-                    levels=cbar_levels,
-                    extend="both",
-                    **opts,
+                    v, ax=ax, x=x, y=y, levels=levels, extend="both", **opts
                 )
             else:
-                v.plot(ax=ax, x=x, y=y, vmax=vmax, **opts)
+                v.plot(ax=ax, x=x, y=y, **plot_kwargs, **opts)
             if ylabel:
                 ax.set_ylabel(ylabel)
             ax.set_title(long_name_and_units)
@@ -134,7 +127,6 @@ def plot_cubed_sphere_map(
     run_metrics: RunMetrics,
     varfilter: str,
     metrics_for_title: Mapping[str, str] = None,
-    **opts,
 ) -> str:
     """Plot horizontal maps of cubed-sphere data for diagnostics which match varfilter.
     
@@ -144,7 +136,6 @@ def plot_cubed_sphere_map(
         varfilter: pattern to filter variable names
         metrics_for_title: metrics to put in plot title. Mapping from label to use in
             plot title to metric_type.
-        opts: additional kwargs to pass to fv3viz.plot_cube
 
     Note:
         All matching diagnostics must have tile, x and y dimensions and each dataset in
@@ -156,8 +147,9 @@ def plot_cubed_sphere_map(
         metrics_for_title = {}
 
     variables_to_plot = run_diags.matching_variables(varfilter)
-    for run in run_diags.runs:
-        for varname in variables_to_plot:
+    for varname in variables_to_plot:
+        plot_kwargs = _get_plot_kwargs(run_diags, varname, robust=True)
+        for run in run_diags.runs:
             logging.info(f"plotting {varname} in {run}")
             shortname = varname.split(varfilter)[0][:-1]
             ds = run_diags.get_variables(run, list(_COORD_VARS) + [varname])
@@ -168,7 +160,7 @@ def plot_cubed_sphere_map(
                 figsize=(6, 3), subplot_kw={"projection": ccrs.Robinson()}
             )
             mv = fv3viz.mappable_var(ds, varname, coord_vars=_COORD_VARS, **COORD_NAMES)
-            fv3viz.plot_cube(mv, ax=ax, **opts)
+            fv3viz.plot_cube(mv, ax=ax, **plot_kwargs)
             ax.set_title(plot_title)
             plt.subplots_adjust(left=0.01, right=0.75, bottom=0.02)
             data[varname][run] = fig_to_b64(fig)
@@ -213,3 +205,12 @@ def _render_map_title(
         metric_units = metrics.get_metric_units(metric_type, variable, run)
         title_parts.append(f"{name_in_figure_title}: {metric_value:.3f} {metric_units}")
     return ", ".join(title_parts)
+
+
+def _get_plot_kwargs(run_diags, variable, robust=False, **kwargs):
+    input_data = []
+    for run in run_diags.runs:
+        input_data.append(run_diags.get_variable(run, variable).assign_coords(run=run))
+    input_data = xr.concat(input_data, dim="run")
+    plot_kwargs = _determine_cmap_params(input_data.values, robust=robust, **kwargs)
+    return {k: plot_kwargs[k] for k in ["vmin", "vmax", "cmap"]}

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/matplotlib.py
@@ -213,4 +213,4 @@ def _get_cmap_kwargs(run_diags, variable, **kwargs):
     for run in run_diags.runs:
         input_data.append(run_diags.get_variable(run, variable).assign_coords(run=run))
     input_data = xr.concat(input_data, dim="run")
-    return fv3viz.auto_limits_cmap(input_data.values, **kwargs)
+    return fv3viz.infer_cmap_params(input_data.values, **kwargs)

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -269,6 +269,7 @@ def zonal_pressure_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
         "pressure_level_zonal_bias",
         ["latitude", "pressure"],
         contour=True,
+        cmap="RdBu_r",
         yincrease=False,
         ylabel="Pressure [Pa]",
     )

--- a/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
+++ b/workflows/prognostic_run_diags/fv3net/diagnostics/prognostic_run/views/static_report.py
@@ -218,16 +218,12 @@ def zonal_mean_plots(diagnostics: Iterable[xr.Dataset]) -> HVPlot:
 
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
-    return plot_2d_matplotlib(
-        diagnostics, "zonal_mean_value", dims=["time", "latitude"], cmap="viridis"
-    )
+    return plot_2d_matplotlib(diagnostics, "zonal_mean_value", ["time", "latitude"])
 
 
 @hovmoller_plot_manager.register
 def zonal_mean_hovmoller_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
-    return plot_2d_matplotlib(
-        diagnostics, "zonal_mean_bias", dims=["time", "latitude"], cmap="RdBu_r",
-    )
+    return plot_2d_matplotlib(diagnostics, "zonal_mean_bias", ["time", "latitude"])
 
 
 def time_mean_cubed_sphere_maps(
@@ -260,8 +256,7 @@ def zonal_pressure_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
     return plot_2d_matplotlib(
         diagnostics,
         "pressure_level_zonal_time_mean",
-        dims=["latitude", "pressure"],
-        cmap="viridis",
+        ["latitude", "pressure"],
         yincrease=False,
         ylabel="Pressure [Pa]",
     )
@@ -272,9 +267,8 @@ def zonal_pressure_bias_plots(diagnostics: Iterable[xr.Dataset]) -> RawHTML:
     return plot_2d_matplotlib(
         diagnostics,
         "pressure_level_zonal_bias",
+        ["latitude", "pressure"],
         contour=True,
-        dims=["latitude", "pressure"],
-        cmap="RdBu_r",
         yincrease=False,
         ylabel="Pressure [Pa]",
     )

--- a/workflows/prognostic_run_diags/tests/test_generate_report.py
+++ b/workflows/prognostic_run_diags/tests/test_generate_report.py
@@ -108,7 +108,6 @@ def test_plot_2d_matplotlib():
         RunDiagnostics([diagnostics, diagnostics.assign_attrs(run="k")]),
         "somefilter",
         dims=["x", "y"],
-        cmap="viridis",
         ylabel="y",
     )
 

--- a/workflows/prognostic_run_diags/tests/test_generate_report.py
+++ b/workflows/prognostic_run_diags/tests/test_generate_report.py
@@ -10,7 +10,10 @@ from fv3net.diagnostics.prognostic_run.computed_diagnostics import (
     RunDiagnostics,
     RunMetrics,
 )
-from fv3net.diagnostics.prognostic_run.views.matplotlib import plot_2d_matplotlib
+from fv3net.diagnostics.prognostic_run.views.matplotlib import (
+    plot_2d_matplotlib,
+    _get_cmap_kwargs,
+)
 from fv3net.diagnostics.prognostic_run.views.static_report import (
     _html_link,
     render_links,
@@ -132,3 +135,18 @@ def test__get_metric_df():
     }
     expected_table = pd.DataFrame(expected_data, index=["run1", "run2"])
     pd.testing.assert_frame_equal(table, expected_table)
+
+
+def test__get_cmap_kwargs():
+    ds = xarray.Dataset(
+        {
+            "wind": (
+                ["x", "y"],
+                np.arange(50).reshape((10, 5)),
+                dict(long_name="longlongname", units="parsec/year"),
+            ),
+        },
+        attrs=dict(run="one-run"),
+    )
+    out = _get_cmap_kwargs(RunDiagnostics([ds, ds.assign_attrs(run="k")]), "wind")
+    assert set(out.keys()) == {"vmin", "vmax", "cmap"}

--- a/workflows/prognostic_run_diags/tests/test_generate_report.py
+++ b/workflows/prognostic_run_diags/tests/test_generate_report.py
@@ -149,4 +149,4 @@ def test__get_cmap_kwargs():
         attrs=dict(run="one-run"),
     )
     out = _get_cmap_kwargs(RunDiagnostics([ds, ds.assign_attrs(run="k")]), "wind")
-    assert set(out.keys()) == {"vmin", "vmax", "cmap"}
+    assert len(out) == 3


### PR DESCRIPTION
Even though we make separate plots for each run on the `maps.html` and `hovmoller.html` pages, it is helpful for all of the plots for a given variable to use a consistent colorbar. This makes comparing between runs a lot easier. This PR provides a public API to some fv3viz functionality that can determine useful cmap params and uses it within the prog run report.

New public API:
- `fv3viz.infer_cmap_params`

Significant internal changes:
- consistent colorbar limits across all runs
- adjust manual contour levels for zonal mean bias plots so that they are symmetric around 0

- [ ] Tests added