### PR TITLE
fv3fit: Fix PureKerasModel.predict to work on unstacked data

### DIFF
--- a/external/fv3fit/fv3fit/keras/_models/recurrent.py
+++ b/external/fv3fit/fv3fit/keras/_models/recurrent.py
@@ -170,7 +170,11 @@ class _BPTTTrainer:
         """
         if self.train_keras_model is not None:
             raise RuntimeError("cannot build, model is already built!")
-        X_tmp = _rename_sample_dim(X, self.sample_dim_name)
+        temporary_sample_dim = self.sample_dim_name + "_tmp"
+        if self.sample_dim_name in X.dims:
+            X_tmp = X.rename({self.sample_dim_name: temporary_sample_dim})
+        else:
+            X_tmp = X
         dataset_2d = stack_non_vertical(X_tmp)
         inputs = self.input_packer.to_array(dataset_2d)
         state = self.prognostic_packer.to_array(dataset_2d)
@@ -610,15 +614,6 @@ class PureKerasModel(Predictor):
                         }
                     )
                 )
-
-
-def _rename_sample_dim(X: xr.Dataset, sample_dim_name: str) -> xr.Dataset:
-    temporary_sample_dim = sample_dim_name + "_tmp"
-    if sample_dim_name in X.dims:
-        X_tmp = X.rename({sample_dim_name: temporary_sample_dim})
-    else:
-        X_tmp = X
-    return X_tmp
 
 
 def _update_ds_with_state(ds, state, sample_dim_name):

--- a/external/fv3fit/fv3fit/keras/_models/recurrent.py
+++ b/external/fv3fit/fv3fit/keras/_models/recurrent.py
@@ -2,7 +2,13 @@ from typing import Dict, Any, Iterable, Hashable, Optional, Sequence, Tuple, Lis
 import tensorflow as tf
 import xarray as xr
 import os
-from ..._shared import Predictor, io, ArrayPacker
+from ..._shared import (
+    Predictor,
+    io,
+    ArrayPacker,
+    SAMPLE_DIM_NAME,
+    match_prediction_to_input_coords,
+)
 from .packer import get_unpack_layer
 from ._filesystem import get_dir, put_dir
 from .normalizer import LayerStandardScaler
@@ -13,19 +19,18 @@ import vcm.safe
 Z_DIMS = ["z", "z_interface"]
 
 
-def stack_non_vertical(ds: xr.Dataset, sample_dim_name) -> xr.Dataset:
+def stack_non_vertical(ds: xr.Dataset) -> xr.Dataset:
     """
     Stack all dimensions except for the Z dimensions into a sample
 
     Args:
         ds: dataset with geospatial dimensions
-        sample_dim_name: name for new sampling dimension
     """
     stack_dims = [dim for dim in ds.dims if dim not in Z_DIMS]
     if len(set(ds.dims).intersection(Z_DIMS)) > 1:
         raise ValueError("Data cannot have >1 feature dimension in {Z_DIMS}.")
     ds_stacked = vcm.safe.stack_once(
-        ds, sample_dim_name, stack_dims, allowed_broadcast_dims=Z_DIMS,
+        ds, SAMPLE_DIM_NAME, stack_dims, allowed_broadcast_dims=Z_DIMS,
     )
     return ds_stacked.transpose()
 
@@ -135,8 +140,8 @@ class _BPTTTrainer:
         )
         self.output_variables = ["dQ1", "dQ2"]
         self.sample_dim_name = sample_dim_name
-        self.input_packer = ArrayPacker(sample_dim_name, input_variables)
-        self.prognostic_packer = ArrayPacker(sample_dim_name, prognostic_variables)
+        self.input_packer = ArrayPacker(SAMPLE_DIM_NAME, input_variables)
+        self.prognostic_packer = ArrayPacker(SAMPLE_DIM_NAME, prognostic_variables)
         self.train_timestep_seconds: Optional[float] = None
         self.input_scaler = LayerStandardScaler()
         self.prognostic_scaler = LayerStandardScaler()
@@ -165,12 +170,8 @@ class _BPTTTrainer:
         """
         if self.train_keras_model is not None:
             raise RuntimeError("cannot build, model is already built!")
-        temporary_sample_dim = self.sample_dim_name + "_tmp"
-        if self.sample_dim_name in X.dims:
-            X_tmp = X.rename({self.sample_dim_name: temporary_sample_dim})
-        else:
-            X_tmp = X
-        dataset_2d = stack_non_vertical(X_tmp, self.sample_dim_name)
+        X_tmp = _rename_sample_dim(X, self.sample_dim_name)
+        dataset_2d = stack_non_vertical(X_tmp)
         inputs = self.input_packer.to_array(dataset_2d)
         state = self.prognostic_packer.to_array(dataset_2d)
         self.input_scaler.fit(inputs)
@@ -542,14 +543,26 @@ class PureKerasModel(Predictor):
 
     def predict(self, X: xr.Dataset) -> xr.Dataset:
         """Predict an output xarray dataset from an input xarray dataset."""
-        inputs = [X[name].values for name in self.input_variables]
+        X_tmp = _rename_sample_dim(X, self.sample_dim_name)
+        X_stacked = stack_non_vertical(X_tmp)
+        inputs = [X_stacked[name].values for name in self.input_variables]
         outputs = self.model.predict(inputs)
         if self._output_metadata is not None:
-            return xr.Dataset(
+            # Special handling for the case where the sample dim is in the input
+            # data requires the unstacking to happen here, so that the original
+            # sample dim coords are available to restore
+            if self.sample_dim_name in X.dims:
+                X_stacked = X_stacked.unstack(SAMPLE_DIM_NAME).rename(
+                    {self.sample_dim_name + "_tmp": self.sample_dim_name}
+                )
+            ds = xr.Dataset(
                 data_vars={
                     name: xr.DataArray(
                         value,
                         dims=metadata["dims"],
+                        # TODO: in addition to match_prediction_to_input_coords,
+                        # referencing X.coords[name] also assumes that model input
+                        # shares common dims with output
                         coords={name: X.coords[name] for name in metadata["dims"]},
                         attrs={"units": metadata["units"]},
                     )
@@ -558,27 +571,32 @@ class PureKerasModel(Predictor):
                     )
                 }
             )
+            if self.sample_dim_name not in X.dims:
+                ds = ds.unstack(SAMPLE_DIM_NAME)
+            return ds
+
         else:
             # workaround for saved datasets which do not have output metadata
             # from an initial version of the BPTT code. Can be removed
             # eventually
             dQ1, dQ2 = outputs
-            return xr.Dataset(
+            ds = xr.Dataset(
                 data_vars={
                     "dQ1": xr.DataArray(
                         dQ1,
-                        dims=X["air_temperature"].dims,
-                        coords=X["air_temperature"].coords,
-                        attrs={"units": X["air_temperature"].units + " / s"},
+                        dims=X_stacked["air_temperature"].dims,
+                        coords=X_stacked["air_temperature"].coords,
+                        attrs={"units": X_stacked["air_temperature"].units + " / s"},
                     ),
                     "dQ2": xr.DataArray(
                         dQ2,
-                        dims=X["specific_humidity"].dims,
-                        coords=X["specific_humidity"].coords,
-                        attrs={"units": X["specific_humidity"].units + " / s"},
+                        dims=X_stacked["specific_humidity"].dims,
+                        coords=X_stacked["specific_humidity"].coords,
+                        attrs={"units": X_stacked["specific_humidity"].units + " / s"},
                     ),
                 }
             )
+            return match_prediction_to_input_coords(X, ds.unstack(SAMPLE_DIM_NAME))
 
     def dump(self, path: str) -> None:
         with put_dir(path) as path:
@@ -596,6 +614,15 @@ class PureKerasModel(Predictor):
                         }
                     )
                 )
+
+
+def _rename_sample_dim(X: xr.Dataset, sample_dim_name: str) -> xr.Dataset:
+    temporary_sample_dim = sample_dim_name + "_tmp"
+    if sample_dim_name in X.dims:
+        X_tmp = X.rename({sample_dim_name: temporary_sample_dim})
+    else:
+        X_tmp = X
+    return X_tmp
 
 
 def _update_ds_with_state(ds, state, sample_dim_name):


### PR DESCRIPTION
The last PR that changed models' `.predict` methods to work on unstacked data forgot to also include the recurrent `PureKerasModel` in this fix.

The handling of how the output metadata gets used to restore coordinates is kind of convoluted; I think the solution that was proposed in discussion (saving an object with the Predictor that stores this info at fit time) would help clean this section up. I made an issue to remind myself not to forget: https://github.com/VulcanClimateModeling/fv3net/issues/1331