### PR TITLE
Use continuumio/miniconda3 for CirceCI image base

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t us.gcr.io/vcm-ml/circleci-miniconda3-gfortran .
+
+push: build
+	docker push us.gcr.io/vcm-ml/circleci-miniconda3-gfortran

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,5 +1,7 @@
-build:
+build_image:
 	docker build -t us.gcr.io/vcm-ml/circleci-miniconda3-gfortran .
 
-push: build
+push_image: build_image
 	docker push us.gcr.io/vcm-ml/circleci-miniconda3-gfortran
+
+.PHONY: build_image push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         type: enum
         enum: ["test_unit", "test_regression", "typecheck", "test_dataflow", "test_prognostic_run_report"]
     docker:
-      - image: us.gcr.io/vcm-ml/circleci-miniconda-gfortran:latest
+      - image: us.gcr.io/vcm-ml/circleci-miniconda3-gfortran:latest
         auth:
           username: _json_key
           password: $DECODED_GOOGLE_CREDENTIALS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,22 +22,12 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "28:8a:c3:e4:58:e7:c0:11:2c:fc:62:84:85:91:1f:7d" # github user key
-      - run: apt-get update && apt-get install -y uuid gnupg
       - run:
-          name: "Setup google-cloud-sdk"
+          name: "Setup google cloud credentials"
           command: |
-            # Install Google Cloud sdk
-            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&\
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-
-            apt-get update && apt-get install -y google-cloud-sdk gfortran
-            gcloud config set project vcm-ml
-
             # Setup credentials
             echo $ENCODED_GOOGLE_CREDENTIALS | \
             base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
-
-
       - run: make update_submodules
       - run:
           name: "Concatenate package dependency files"

--- a/.circleci/dockerfile
+++ b/.circleci/dockerfile
@@ -1,8 +1,18 @@
 FROM continuumio/miniconda3:latest
 
-RUN apt-get update && apt-get install -y curl gfortran make && \
+RUN apt-get update && apt-get install -y \
+    curl \
+    gfortran \
+    make \
+    uuid \
+    gnupg && \
     apt-get clean && \
     conda update -n base conda && \
     conda clean -i
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get install -y google-cloud-sdk && \
+    gcloud config set project vcm-ml
 
 CMD [ "/bin/bash" ]

--- a/.circleci/dockerfile
+++ b/.circleci/dockerfile
@@ -1,13 +1,6 @@
-FROM continuumio/miniconda:latest
+FROM continuumio/miniconda3:latest
 
-# https://askubuntu.com/questions/51854/is-it-possible-to-install-a-deb-from-a-url
-# linux-libc-dev is a broken uri for the apt-get repository that's checked in miniconda
-RUN apt-get install -y curl && \
-    curl -L "http://security-cdn.debian.org/debian-security/pool/updates/main/l/linux/linux-libc-dev_4.19.67-2+deb10u2_amd64.deb" > linux-libc-dev.deb && \
-    dpkg -i linux-libc-dev.deb && \
-    rm -f linux-libc-dev.deb && \
-    apt-get install -y gfortran && \
-    apt-get install -y make && \
+RUN apt-get update && apt-get install -y curl gfortran make && \
     apt-get clean && \
     conda update -n base conda && \
     conda clean -i

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ push_image_%: build_image_%
 pull_image_%:
 	docker pull $(REGISTRY)/$*:$(VERSION)
 
-build_image_ci:
-	docker build -t us.gcr.io/vcm-ml/circleci-miniconda-gfortran:latest - < .circleci/dockerfile
-
 ############################################################
 # Documentation (rules match "deploy_docs_%")
 ############################################################


### PR DESCRIPTION
The image we use for `test_unit` and a couple other CI tests is based off an old continuumio image that has not been updated for a couple years. This PR updates the dockerfile which built our CI image to use a newer one, and updates the CircleCI config to use the new image which I manually built and pushed.

Edit: it also moves the installation of `google-cloud-sdk` into the building of our CI image, which should save ~30s on each test.