### PR TITLE
prognostic run: Ensure initial_time used in diagnostic configs is cftime.DatetimeJulian

### DIFF
--- a/external/vcm/vcm/__init__.py
+++ b/external/vcm/vcm/__init__.py
@@ -15,6 +15,7 @@ from .convenience import (
     cast_to_datetime,
     encode_time,
     shift_timestamp,
+    round_time,
 )
 from .calc import r2_score, local_time, thermo, cos_zenith_angle
 from .calc.thermo import (

--- a/workflows/prognostic_c48_run/runtime/derived_state.py
+++ b/workflows/prognostic_c48_run/runtime/derived_state.py
@@ -5,7 +5,7 @@ from toolz import dissoc
 import xarray as xr
 
 import fv3gfs.util
-from vcm import DerivedMapping
+from vcm import DerivedMapping, round_time
 from runtime.names import DELP
 from runtime.types import State
 
@@ -81,7 +81,8 @@ class DerivedFV3State(MutableMapping):
 
     @property
     def time(self) -> cftime.DatetimeJulian:
-        return self._getter.get_state(["time"])["time"]
+        state_time = self._getter.get_state(["time"])["time"]
+        return round_time(cftime.DatetimeJulian(*state_time.timetuple()))
 
     def __getitem__(self, key: Hashable) -> xr.DataArray:
         return self._mapper[key]

--- a/workflows/prognostic_c48_run/runtime/diagnostics/time.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/time.py
@@ -10,6 +10,7 @@ from typing import (
 
 import cftime
 import datetime
+import vcm
 
 
 class All(Container):
@@ -47,7 +48,10 @@ class SelectedTimes(Container[cftime.DatetimeJulian]):
 
     @property
     def times(self) -> Sequence[cftime.DatetimeJulian]:
-        return [cftime.DatetimeJulian(*time.timetuple()) for time in self._times]
+        return [
+            vcm.round_time(cftime.DatetimeJulian(*time.timetuple()))
+            for time in self._times
+        ]
 
     def __contains__(self, time: cftime.DatetimeJulian) -> bool:
         return time in self.times

--- a/workflows/prognostic_c48_run/runtime/segmented_run/validate.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/validate.py
@@ -3,6 +3,8 @@ from typing import Any, Mapping, Union
 
 import dacite
 import fv3config
+import cftime
+
 from ..config import UserConfig, DiagnosticFileConfig
 from ..diagnostics.fortran import FortranFileConfig
 
@@ -16,7 +18,9 @@ def validate_chunks(config_dict: Mapping[str, Any]):
     output diagnostics. Raise ConfigValidationError if not."""
     user_config = dacite.from_dict(UserConfig, config_dict)
     run_duration = fv3config.get_run_duration(config_dict)
-    initial_time = datetime(*config_dict["namelist"]["coupler_nml"]["current_date"])
+    initial_time = cftime.DatetimeJulian(
+        *config_dict["namelist"]["coupler_nml"]["current_date"]
+    )
     timestep = timedelta(seconds=config_dict["namelist"]["coupler_nml"]["dt_atmos"])
 
     for diag_file_config in user_config.diagnostics:

--- a/workflows/prognostic_c48_run/runtime/segmented_run/validate.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/validate.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, Union
 import dacite
 import fv3config
 import cftime
+import vcm
 
 from ..config import UserConfig, DiagnosticFileConfig
 from ..diagnostics.fortran import FortranFileConfig
@@ -18,8 +19,8 @@ def validate_chunks(config_dict: Mapping[str, Any]):
     output diagnostics. Raise ConfigValidationError if not."""
     user_config = dacite.from_dict(UserConfig, config_dict)
     run_duration = fv3config.get_run_duration(config_dict)
-    initial_time = cftime.DatetimeJulian(
-        *config_dict["namelist"]["coupler_nml"]["current_date"]
+    initial_time = vcm.round_time(
+        cftime.DatetimeJulian(*config_dict["namelist"]["coupler_nml"]["current_date"])
     )
     timestep = timedelta(seconds=config_dict["namelist"]["coupler_nml"]["dt_atmos"])
 


### PR DESCRIPTION
The initial time arg to some of the time related functions is sometimes a datetime.datetime instead of cftime.DatetimeJulian, which raised an error when trying to do comparisions in the `SelectedTimes` time container. 

This also adds time rounding to the `SelectedTimes` container to ensure that the conversion to DatetimeJulian doesn't end up with a slight offset from start of the minute, which in turn results in no selected times getting saved.

