### PR TITLE
fix and test transect snapshot functionality of offline report

### DIFF
--- a/workflows/offline_ml_diags/offline_ml_diags/_helpers.py
+++ b/workflows/offline_ml_diags/offline_ml_diags/_helpers.py
@@ -1,4 +1,3 @@
-import fsspec
 import json
 import numpy as np
 import os
@@ -177,18 +176,20 @@ def open_diagnostics_outputs(
     metrics_json_name: str,
     metadata_json_name: str,
 ) -> Tuple[xr.Dataset, xr.Dataset, xr.Dataset, dict, dict]:
-    with fsspec.open(os.path.join(data_dir, diagnostics_nc_name), "rb") as f:
+    fs = vcm.get_fs(data_dir)
+    with fs.open(os.path.join(data_dir, diagnostics_nc_name), "rb") as f:
         ds_diags = xr.open_dataset(f).load()
-    with fsspec.open(os.path.join(data_dir, diurnal_nc_name), "rb") as f:
+    with fs.open(os.path.join(data_dir, diurnal_nc_name), "rb") as f:
         ds_diurnal = xr.open_dataset(f).load()
-    if vcm.get_fs(data_dir).exists(os.path.join(data_dir, transect_nc_name)):
-        with fsspec.open(os.path.join(data_dir, transect_nc_name), "rb") as f:
+    transect_full_path = os.path.join(data_dir, transect_nc_name)
+    if fs.exists(transect_full_path):
+        with fs.open(transect_full_path, "rb") as f:
             ds_transect = xr.open_dataset(f).load()
     else:
         ds_transect = xr.Dataset()
-    with fsspec.open(os.path.join(data_dir, metrics_json_name), "r") as f:
+    with fs.open(os.path.join(data_dir, metrics_json_name), "r") as f:
         metrics = json.load(f)
-    with fsspec.open(os.path.join(data_dir, metadata_json_name), "r") as f:
+    with fs.open(os.path.join(data_dir, metadata_json_name), "r") as f:
         metadata = json.load(f)
     return ds_diags, ds_diurnal, ds_transect, metrics, metadata
 

--- a/workflows/offline_ml_diags/tests/test_compute_diags.py
+++ b/workflows/offline_ml_diags/tests/test_compute_diags.py
@@ -90,8 +90,16 @@ def test_offline_diags_integration(data_path, grid_dataset_path):  # noqa: F811
             grid=grid_dataset_path,
         )
         compute_diags.main(compute_diags_args)
+        if isinstance(data_config, loaders.BatchesFromMapperConfig):
+            assert "transect_lon0.nc" in os.listdir(
+                os.path.join(tmpdir, "offline_diags")
+            )
         create_report_args = CreateReportArgs(
             input_path=os.path.join(tmpdir, "offline_diags"),
             output_path=os.path.join(tmpdir, "report"),
         )
         create_report.main(create_report_args)
+        with open(os.path.join(tmpdir, "report/index.html")) as f:
+            report = f.read()
+        if isinstance(data_config, loaders.BatchesFromMapperConfig):
+            assert "Transect snapshot at" in report


### PR DESCRIPTION
The PR adding loaders data configuration intended that the offline diags report includes transect snapshots if a "batches from mapper" configuration is provided, such that it can grab a mapper's single data output. However this feature was not working due to a bug in the report generation tool. This PR adds assertions that this part of the report is produced when a BatchesFromMapperConfig is used in the report generation integration test, and fixes the code to produce that part of the report.

Significant internal changes:
- Fixed bug in offline_ml_diags.create_report which would cause transect snapshot to never be reported, even if its netcdf file is present

- [*] Tests added

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).