### PR TITLE
Online emulator fv3fit changes

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -97,6 +97,7 @@ hdfs==2.5.8
 holoviews==1.14.1
 html5lib==1.1
 httplib2==0.17.4
+hypothesis==6.15.0
 identify==2.2.4
 idna==2.9
 imagesize==1.2.0
@@ -218,6 +219,7 @@ six==1.15.0
 smmap==4.0.0
 sniffio==1.2.0
 snowballstemmer==2.0.0
+sortedcontainers==2.4.0
 sphinx-argparse==0.2.5
 sphinx-gallery==0.8.2
 sphinx-rtd-theme==0.5.0

--- a/external/fv3fit/docs/emulation_data.rst
+++ b/external/fv3fit/docs/emulation_data.rst
@@ -5,8 +5,24 @@ Emulation Data Tools
 
 ``fv3fit.emulation.data`` contains a set of composable transforms useful for building training input pipelines, an input transform configuration, and convenience functions for creating tensorflow datasets from a sequence of data.
 
-Example
--------
+.. _dict-outputs-data:
+
+Dict-output data loaders
+------------------------
+
+When data transformations are contained in a custom training loop or the ML model
+code, it is convenient to load a directory of netcdfs as a tensorflow dataset of
+dictionaries using :py:func:`fv3fit.emulation.data.netcdf_url_to_dataset`. 
+This format is compatible ``keras`` models `.fit` method. 
+
+Tuple-output data loaders
+-------------------------
+
+Sometimes it is more convenenient to move pre-processing logic like spatial
+subselection into the data loading pipeline. 
+This allows using one "model" or "loss" function for multiple machine learning
+problems.
+For methods that insert physical priors into the model training (e.g. relative humidity based losses or models) it may be preferable to use dict-outputs-data_.
 
 Here we show use of our standard input transformation configuration to go from a directory of netCDF files to grouped per-variable input and target tuples for keras training.
 

--- a/external/fv3fit/fv3fit/emulation/data/__init__.py
+++ b/external/fv3fit/fv3fit/emulation/data/__init__.py
@@ -2,3 +2,4 @@ from .config import TransformConfig
 from . import transforms
 from .load import nc_files_to_tf_dataset, nc_dir_to_tf_dataset, batches_to_tf_dataset
 from .io import get_nc_files
+from .dict_dataset import netcdf_url_to_dataset

--- a/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
+++ b/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
@@ -1,0 +1,56 @@
+from typing import Sequence
+import tensorflow as tf
+import vcm
+import xarray as xr
+from fv3fit.emulation.data.io import get_nc_files
+
+__all__ = ["netcdf_url_to_dataset"]
+
+
+def get_data(ds, variables) -> tf.Tensor:
+    def convert(array: xr.DataArray):
+        return tf.convert_to_tensor(array, dtype=tf.float32)
+
+    return tuple([convert(ds[v]) for v in variables])
+
+
+def read_image_from_url(fs, url, variables):
+    sig = (tf.float32,) * len(variables)
+
+    outputs = tf.py_function(lambda url: open_url(fs, url, variables), [url], sig)
+    return dict(zip(variables, outputs))
+
+
+def open_url(fs, url, variables):
+    url = url.numpy().decode()
+    print(f"opening {url}")
+    return get_data(vcm.open_remote_nc(fs, url), variables)
+
+
+def netcdf_url_to_dataset(
+    url: str, variables: Sequence[str], shuffle: bool = False
+) -> tf.data.Dataset:
+    """Open a url of netcdfs as a tf.data.Dataset of dicts
+
+    Args:
+        url: points to a directory of netcdf files.
+        variables: a sequence of variable names to load from each netcdf file
+        shuffle: if True, shuffle order the netcdf files will be loaded in. Does
+            not shuffle BETWEEN files.
+    
+    Returns:
+        a  tensorflow dataset containing dictionaries of tensors. This
+        dictionary contains all the variables specified in ``variables``.
+    """
+    fs = vcm.get_fs(url)
+    files = get_nc_files(url, fs)
+    d = tf.data.Dataset.from_tensor_slices(sorted(files))
+    if shuffle:
+        d = d.shuffle(100_000)
+    return d.map(lambda url: read_image_from_url(fs, url, variables))
+
+
+def load_samples(train_dataset, n_train):
+    n_train = 50_000
+    train_data = train_dataset.take(n_train).shuffle(n_train).batch(n_train)
+    return next(iter(train_data))

--- a/external/fv3fit/fv3fit/emulation/layers/normalization.py
+++ b/external/fv3fit/fv3fit/emulation/layers/normalization.py
@@ -2,6 +2,15 @@ import abc
 import tensorflow as tf
 
 
+def standard_deviation_all_features(tensor):
+    """Commpute standard deviation across all features
+
+    A separate mean is computed for each output level
+    """
+    mean = tf.cast(tf.reduce_mean(tensor, axis=0), tf.float32)
+    return tf.cast(tf.sqrt(tf.reduce_mean((tensor - mean) ** 2)), tf.float32,)
+
+
 class NormLayer(tf.keras.layers.Layer, abc.ABC):
     def __init__(self, name=None, **kwargs):
         super(NormLayer, self).__init__(name=name)
@@ -86,6 +95,11 @@ class FeatureMaxStd(NormLayer):
         self.sigma.assign(max_std)
 
 
+class FeatureMeanStd(FeatureMaxStd):
+    def _fit_sigma(self, tensor: tf.Tensor) -> None:
+        self.sigma.assign(standard_deviation_all_features(tensor))
+
+
 class StandardNormLayer(PerFeatureMean, PerFeatureStd):
     """
     Normalization layer that removes mean and standard
@@ -135,3 +149,11 @@ class MaxFeatureStdDenormLayer(MaxFeatureStdNormLayer):
 
     def call(self, tensor):
         return tensor * self.sigma + self.mean
+
+
+class FeatureMeanDenormLayer(MaxFeatureStdDenormLayer, FeatureMeanStd):
+    """De-normalization layer that scales all outputs by the standard deviation
+    computed from the per-feature mean.
+    """
+
+    pass

--- a/external/fv3fit/fv3fit/emulation/thermo.py
+++ b/external/fv3fit/fv3fit/emulation/thermo.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+from vcm.calc.thermo import _GRAVITY, _RVGAS
+
+
+def saturation_pressure(air_temperature_kelvin: tf.Tensor) -> tf.Tensor:
+    """The August Roche Magnus formula for saturation vapor pressure
+    
+    https://en.wikipedia.org/wiki/Clausius%E2%80%93Clapeyron_relation#Meteorology_and_climatology # noqa
+    
+    """
+    celsius = air_temperature_kelvin - 273.15
+    return 610.94 * tf.exp(17.625 * celsius / (celsius + 243.04))
+
+
+def relative_humidity(
+    air_temperature_kelvin: tf.Tensor, specific_humidity: tf.Tensor, rho: tf.Tensor
+):
+    partial_pressure = _RVGAS * specific_humidity * rho * air_temperature_kelvin
+    return partial_pressure / saturation_pressure(air_temperature_kelvin)
+
+
+def specific_humidity_from_rh(
+    air_temperature_kelvin, relative_humidity, rho: tf.Tensor
+):
+    es = saturation_pressure(air_temperature_kelvin)
+    partial_pressure = relative_humidity * es
+
+    return partial_pressure / _RVGAS / rho / air_temperature_kelvin
+
+
+def density(delp, delz):
+    return tf.abs(delp / delz / _GRAVITY)
+
+
+def pressure_thickness(rho, delz):
+    return tf.abs(rho * delz * _GRAVITY)

--- a/external/fv3fit/setup.py
+++ b/external/fv3fit/setup.py
@@ -19,7 +19,7 @@ requirements = [
 
 setup_requirements = []
 
-test_requirements = ["pytest"]
+test_requirements = ["pytest", "hypothesis"]
 
 setup(
     author="Vulcan Technologies LLC",

--- a/external/fv3fit/tests/emulation/test_thermo.py
+++ b/external/fv3fit/tests/emulation/test_thermo.py
@@ -1,0 +1,37 @@
+import tensorflow as tf
+from fv3fit.emulation.thermo import relative_humidity, specific_humidity_from_rh
+from vcm.calc.thermo import _RDGAS, _RVGAS
+import pytest
+
+from hypothesis import given
+from hypothesis.strategies import floats
+
+
+@pytest.mark.parametrize("celsius, rh", [(26, 0.5), (14.77, 1.0)])
+def test_relative_humidity(celsius, rh):
+    """
+    Compare withh https://www.omnicalculator.com/physics/air-density
+    """
+
+    rho = 1.1781
+    p = 1018_00
+    e = 16_79.30
+
+    q = _RDGAS / _RVGAS * e / (p - e)
+    rho = tf.Variable(rho)
+
+    T = tf.Variable(celsius + 273.15)
+    ans = relative_humidity(T, q, rho)
+
+    assert pytest.approx(rh, rel=0.03) == ans.numpy()
+
+
+@given(floats(200, 400), floats(0, 1), floats(1, 100))
+def test_specific_humidity(t, rh, rho):
+    """
+    Compare withh https://www.omnicalculator.com/physics/air-density
+    """
+    q = specific_humidity_from_rh(t, rh, rho)
+    rh_round_trip = relative_humidity(t, q, rho)
+
+    assert pytest.approx(rh) == rh_round_trip

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -45,3 +45,7 @@ pip-tools
 poetry
 tox
 pre-commit
+
+# fv3fit test requirements
+# pip compile does not include test requirements for some reason
+hypothesis


### PR DESCRIPTION
#1265 is too big. Here are some new APIs in fv3fit that I found useful there, and could be used more widely. These are mostly some simple functions. To be rebased/merged.

Requirement changes:
- Bulleted list, if relevant, of any changes to setup.py, requirement.txt, environment.yml, etc
- [x] Ran `make lock_deps/lock_pip` following these [instructions](https://vulcanclimatemodeling.com/docs/fv3net/dependency_management.html#dependency-management)
- [ ] Add PR review with license info for any additions to `constraints.txt`
  ([example](https://github.com/VulcanClimateModeling/fv3net/pull/1218#pullrequestreview-663644359))