### PR TITLE
Move input/output variables to hyperparameters

### DIFF
--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -234,9 +234,7 @@ class RandomForestHyperparameters(Hyperparameters):
     Args:
         input_variables: names of variables to use as inputs
         output_variables: names of variables to use as outputs
-        scaler_type: scaler to use for training, must be "standard" or "mass".
-            If set to "mass", then "pressure_thickness_of_atmospheric_layer" must
-            be included in the TrainingConfig `additional_variables` field.
+        scaler_type: scaler to use for training, must be "standard" or "mass"
         scaler_kwargs: keyword arguments to pass to scaler initialization
         n_jobs: number of jobs to run in parallel when training a single random forest
         random_state: random seed to use when building trees, will be
@@ -273,4 +271,8 @@ class RandomForestHyperparameters(Hyperparameters):
 
     @property
     def variables(self) -> Set[str]:
-        return set(self.input_variables).union(self.output_variables)
+        if self.scaler_type == "mass":
+            additional_variables = ["pressure_thickness_of_atmospheric_layer"]
+        else:
+            additional_variables = []
+        return set(self.input_variables).union(self.output_variables).union(additional_variables)

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -15,9 +15,11 @@ from typing import (
 from fv3fit.typing import Dataclass
 import xarray as xr
 from .predictor import Predictor
+from .hyperparameters import Hyperparameters
 import dacite
 import numpy as np
 import random
+import warnings
 
 # TODO: move all keras configs under fv3fit.keras
 import tensorflow as tf
@@ -60,8 +62,6 @@ class TrainingConfig:
         input_variables: variables used as features
         output_variables: variables to predict
         hyperparameters: model_type-specific training configuration
-        additional_variables: variables needed for training which aren't input
-            or output variables of the trained model
         sample_dim_name: deprecated, internal name used for sample dimension
             when training and predicting
         random_seed: value to use to initialize randomness
@@ -71,17 +71,34 @@ class TrainingConfig:
     """
 
     model_type: str
-    input_variables: List[str]
-    output_variables: List[str]
-    hyperparameters: Dataclass
-    additional_variables: List[str] = dataclasses.field(default_factory=list)
+    hyperparameters: Hyperparameters
     sample_dim_name: str = "sample"
     random_seed: Union[float, int] = 0
     derived_output_variables: List[str] = dataclasses.field(default_factory=list)
 
+    @property
+    def variables(self):
+        return self.hyperparameters.variables
+
     @classmethod
     def from_dict(cls, kwargs) -> "TrainingConfig":
         kwargs = {**kwargs}  # make a copy to avoid mutating the input
+        if "input_variables" in kwargs:
+            warnings.warn(
+                "input_variables is no longer a top-level TrainingConfig "
+                "parameter, pass it under hyperparameters instead",
+                DeprecationWarning,
+            )
+            kwargs["hyperparameters"]["input_variables"] = kwargs.pop("input_variables")
+        if "output_variables" in kwargs:
+            warnings.warn(
+                "output_variables is no longer a top-level TrainingConfig "
+                "parameter, pass it under hyperparameters instead",
+                DeprecationWarning,
+            )
+            kwargs["hyperparameters"]["output_variables"] = kwargs.pop(
+                "output_variables"
+            )
         hyperparameter_class = get_hyperparameter_class(kwargs["model_type"])
         kwargs["hyperparameters"] = dacite.from_dict(
             data_class=hyperparameter_class, data=kwargs.get("hyperparameters", {})
@@ -146,11 +163,13 @@ class RegularizerConfig:
 # TODO: move this class to where the Dense training is defined when config.py
 # no longer depends on it (i.e. when _ModelTrainingConfig is deleted)
 @dataclasses.dataclass
-class DenseHyperparameters:
+class DenseHyperparameters(Hyperparameters):
     """
     Configuration for training a dense neural network based model.
 
     Args:
+        input_variables: names of variables to use as inputs
+        output_variables: names of variables to use as outputs
         weights: loss function weights, defined as a dict whose keys are
             variable names and values are either a scalar referring to the total
             weight of the variable. Default is a total weight of 1
@@ -176,6 +195,8 @@ class DenseHyperparameters:
             tf.keras.Model.fit() method
     """
 
+    input_variables: List[str]
+    output_variables: List[str]
     weights: Optional[Mapping[str, Union[int, float]]] = None
     normalize_loss: bool = True
     optimizer_config: OptimizerConfig = dataclasses.field(
@@ -194,9 +215,13 @@ class DenseHyperparameters:
     # TODO: remove fit_kwargs by fixing how validation data is passed
     fit_kwargs: Optional[dict] = None
 
+    @property
+    def variables(self) -> Sequence[str]:
+        return list(set(self.input_variables).union(self.output_variables))
+
 
 @dataclasses.dataclass
-class RandomForestHyperparameters:
+class RandomForestHyperparameters(Hyperparameters):
     """
     Configuration for training a random forest based model.
 
@@ -206,6 +231,8 @@ class RandomForestHyperparameters:
     `sklearn.ensemble.RandomForestRegressor`.
 
     Args:
+        input_variables: names of variables to use as inputs
+        output_variables: names of variables to use as outputs
         scaler_type: scaler to use for training, must be "standard" or "mass".
             If set to "mass", then "pressure_thickness_of_atmospheric_layer" must
             be included in the TrainingConfig `additional_variables` field.
@@ -226,6 +253,9 @@ class RandomForestHyperparameters:
             If False, the whole dataset is used to build each tree.
     """
 
+    input_variables: List[str]
+    output_variables: List[str]
+
     scaler_type: str = "standard"
     scaler_kwargs: Optional[Mapping] = None
 
@@ -239,3 +269,7 @@ class RandomForestHyperparameters:
     max_features: Union[str, int, float] = "auto"
     max_samples: Optional[Union[int, float]] = None
     bootstrap: bool = True
+
+    @property
+    def variables(self) -> Sequence[str]:
+        return list(set(self.input_variables).union(self.output_variables))

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -60,8 +60,6 @@ class TrainingConfig:
 
     Attrs:
         model_type: sklearn model type or keras model class to initialize
-        input_variables: variables used as features
-        output_variables: variables to predict
         hyperparameters: model_type-specific training configuration
         sample_dim_name: deprecated, internal name used for sample dimension
             when training and predicting
@@ -275,4 +273,8 @@ class RandomForestHyperparameters(Hyperparameters):
             additional_variables = ["pressure_thickness_of_atmospheric_layer"]
         else:
             additional_variables = []
-        return set(self.input_variables).union(self.output_variables).union(additional_variables)
+        return (
+            set(self.input_variables)
+            .union(self.output_variables)
+            .union(additional_variables)
+        )

--- a/external/fv3fit/fv3fit/_shared/config.py
+++ b/external/fv3fit/fv3fit/_shared/config.py
@@ -8,6 +8,7 @@ from typing import (
     Tuple,
     Union,
     Sequence,
+    Set,
     List,
     Type,
     Dict,
@@ -216,8 +217,8 @@ class DenseHyperparameters(Hyperparameters):
     fit_kwargs: Optional[dict] = None
 
     @property
-    def variables(self) -> Sequence[str]:
-        return list(set(self.input_variables).union(self.output_variables))
+    def variables(self) -> Set[str]:
+        return set(self.input_variables).union(self.output_variables)
 
 
 @dataclasses.dataclass
@@ -271,5 +272,5 @@ class RandomForestHyperparameters(Hyperparameters):
     bootstrap: bool = True
 
     @property
-    def variables(self) -> Sequence[str]:
-        return list(set(self.input_variables).union(self.output_variables))
+    def variables(self) -> Set[str]:
+        return set(self.input_variables).union(self.output_variables)

--- a/external/fv3fit/fv3fit/_shared/hyperparameters.py
+++ b/external/fv3fit/fv3fit/_shared/hyperparameters.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Sequence
+from typing import Set
 
 
 class Hyperparameters(abc.ABC):
@@ -10,5 +10,5 @@ class Hyperparameters(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def variables(self) -> Sequence[str]:
+    def variables(self) -> Set[str]:
         pass

--- a/external/fv3fit/fv3fit/_shared/hyperparameters.py
+++ b/external/fv3fit/fv3fit/_shared/hyperparameters.py
@@ -1,0 +1,14 @@
+import abc
+from typing import Sequence
+
+
+class Hyperparameters(abc.ABC):
+    """
+    Attributes:
+        variables: names of data variables required to train the model
+    """
+
+    @property
+    @abc.abstractmethod
+    def variables(self) -> Sequence[str]:
+        pass

--- a/external/fv3fit/fv3fit/keras/_models/models.py
+++ b/external/fv3fit/fv3fit/keras/_models/models.py
@@ -44,13 +44,16 @@ History = Mapping[str, EpochLossHistory]
 
 @register_training_function("DenseModel", DenseHyperparameters)
 def train_dense_model(
-    input_variables: Iterable[str],
-    output_variables: Iterable[str],
     hyperparameters: DenseHyperparameters,
     train_batches: Sequence[xr.Dataset],
     validation_batches: Sequence[xr.Dataset],
 ):
-    model = DenseModel("sample", input_variables, output_variables, hyperparameters)
+    model = DenseModel(
+        "sample",
+        hyperparameters.input_variables,
+        hyperparameters.output_variables,
+        hyperparameters,
+    )
     # TODO: make use of validation_batches, currently validation dataset is
     # passed through hyperparameters.fit_kwargs
     model.fit(train_batches)

--- a/external/fv3fit/fv3fit/sklearn/_random_forest.py
+++ b/external/fv3fit/fv3fit/sklearn/_random_forest.py
@@ -42,13 +42,16 @@ def _tuple_to_multiindex(d: tuple) -> pd.MultiIndex:
 
 @register_training_function("sklearn_random_forest", RandomForestHyperparameters)
 def train_random_forest(
-    input_variables: Iterable[str],
-    output_variables: Iterable[str],
     hyperparameters: RandomForestHyperparameters,
     train_batches: Sequence[xr.Dataset],
     validation_batches: Sequence[xr.Dataset],
 ):
-    model = RandomForest("sample", input_variables, output_variables, hyperparameters)
+    model = RandomForest(
+        "sample",
+        hyperparameters.input_variables,
+        hyperparameters.output_variables,
+        hyperparameters,
+    )
     # TODO: make use of validation_batches to report validation loss
     model.fit(train_batches)
     return model

--- a/external/fv3fit/fv3fit/train.py
+++ b/external/fv3fit/fv3fit/train.py
@@ -64,13 +64,8 @@ def main(args):
         training_data_config, os.path.join(args.output_path, "training_data.yaml")
     )
 
-    all_variables = (
-        training_config.input_variables
-        + training_config.output_variables
-        + training_config.additional_variables
-    )
     train_batches: loaders.typing.Batches = training_data_config.load_batches(
-        variables=all_variables
+        variables=training_config.variables
     )
     if args.validation_data_config is not None:
         with open(args.validation_data_config, "r") as f:
@@ -79,7 +74,9 @@ def main(args):
             validation_data_config,
             os.path.join(args.output_path, "validation_data.yaml"),
         )
-        val_batches = validation_data_config.load_batches(variables=all_variables)
+        val_batches = validation_data_config.load_batches(
+            variables=training_config.variables
+        )
     else:
         val_batches: Sequence[xr.Dataset] = []
 
@@ -93,8 +90,6 @@ def main(args):
 
     train = fv3fit.get_training_function(training_config.model_type)
     model = train(
-        input_variables=training_config.input_variables,
-        output_variables=training_config.output_variables,
         hyperparameters=training_config.hyperparameters,
         train_batches=train_batches,
         validation_batches=val_batches,

--- a/external/fv3fit/tests/test__config.py
+++ b/external/fv3fit/tests/test__config.py
@@ -30,9 +30,9 @@ def test_safe_dump_training_config():
     # TODO: extend this test to run not just for Dense, but for all registered models
     config = TrainingConfig(
         model_type="DenseModel",  # an arbitrary model type
-        input_variables=["a"],
-        output_variables=["b"],
-        hyperparameters=DenseHyperparameters(),
+        hyperparameters=DenseHyperparameters(
+            input_variables=["a"], output_variables=["b"],
+        ),
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         filename = os.path.join(tmpdir, "config.yaml")

--- a/external/fv3fit/tests/test_models.py
+++ b/external/fv3fit/tests/test_models.py
@@ -34,7 +34,7 @@ def test_DenseModel_jacobian(base_state):
             "b": (["x", "z"], np.arange(10).reshape(2, 5)),
         }
     )
-    model = IdentityModel("sample", ["a"], ["b"], DenseHyperparameters())
+    model = IdentityModel("sample", ["a"], ["b"], DenseHyperparameters(["a"], ["b"]))
     model.fit([batch])
     if base_state == "manual":
         jacobian = model.jacobian(batch[["a"]].isel(x=0))
@@ -62,7 +62,9 @@ def test_fill_default(kwargs, arg, key, default, expected):
 
 
 def test_nonnegative_model_outputs():
-    hyperparameters = DenseHyperparameters(nonnegative_outputs=True)
+    hyperparameters = DenseHyperparameters(
+        ["input"], ["output"], nonnegative_outputs=True
+    )
     model = DenseModel("sample", ["input"], ["output"], hyperparameters,)
     batch = xr.Dataset(
         {

--- a/external/fv3fit/tests/training/test_main.py
+++ b/external/fv3fit/tests/training/test_main.py
@@ -2,6 +2,8 @@ import dataclasses
 import subprocess
 from typing import Any, Optional, Sequence
 import fv3fit
+from fv3fit._shared.config import get_hyperparameter_class
+from fv3fit._shared.hyperparameters import Hyperparameters
 import fv3fit.train
 from fv3fit._shared.io import register
 import yaml
@@ -62,8 +64,8 @@ class MockHyperparameters:
 @dataclasses.dataclass
 class TestConfig:
     args: MainArgs
-    input_variables: Sequence[str]
-    output_variables: Sequence[str]
+    variables: Sequence[str]
+    hyperparameters: Hyperparameters
     output_path: str
     mock_dataset: xr.Dataset
 
@@ -71,10 +73,8 @@ class TestConfig:
 @dataclasses.dataclass
 class CallArtifacts:
     output_path: str
-    all_variables: Sequence[str]
+    variables: Sequence[str]
     MockDerivedModel: mock.Mock
-    input_variables: Sequence[str]
-    output_variables: Sequence[str]
     hyperparameters: Any
 
 
@@ -106,49 +106,34 @@ def mock_load_batches():
 
 
 def call_main(
-    tmpdir,
-    mock_load_batches,
-    additional_variables,
-    derived_output_variables,
-    use_validation_data: bool,
+    tmpdir, mock_load_batches, derived_output_variables, use_validation_data: bool,
 ):
     model_type = "DenseModel"
-    hyperparameters = fv3fit.DenseHyperparameters(depth=2, width=8)
+    hyperparameters_dict = {"depth": 2, "width": 8}
     config = get_config(
         tmpdir,
-        additional_variables,
         derived_output_variables,
         model_type,
-        hyperparameters,
+        hyperparameters_dict,
         use_validation_data,
     )
     mock_load_batches.return_value = [config.mock_dataset for _ in range(6)]
-    all_variables = (
-        config.input_variables + config.output_variables + additional_variables
-    )
     with mock.patch("fv3fit.DerivedModel") as MockDerivedModel:
         MockDerivedModel.return_value = mock.MagicMock(
             name="derived_model_return", spec=fv3fit.Predictor
         )
         fv3fit.train.main(config.args)
     return CallArtifacts(
-        config.output_path,
-        all_variables,
-        MockDerivedModel,
-        config.input_variables,
-        config.output_variables,
-        hyperparameters,
+        config.output_path, config.variables, MockDerivedModel, config.hyperparameters,
     )
 
 
-@pytest.mark.parametrize("additional_variables", [[], ["downward_shortwave"]])
 @pytest.mark.parametrize("derived_output_variables", [[], ["downwelling_shortwave"]])
 @pytest.mark.parametrize("use_validation_data", [True, False])
 def test_main_calls_load_batches_correctly(
     tmpdir,
     mock_load_batches: mock.MagicMock,
     mock_train_dense_model: mock.MagicMock,
-    additional_variables: Sequence[str],
     derived_output_variables: Sequence[str],
     use_validation_data: bool,
 ):
@@ -157,13 +142,9 @@ def test_main_calls_load_batches_correctly(
     and data loading.
     """
     artifacts = call_main(
-        tmpdir,
-        mock_load_batches,
-        additional_variables,
-        derived_output_variables,
-        use_validation_data,
+        tmpdir, mock_load_batches, derived_output_variables, use_validation_data,
     )
-    mock_load_batches.assert_called_with(variables=artifacts.all_variables)
+    mock_load_batches.assert_called_with(variables=artifacts.variables)
     if use_validation_data:
         assert (
             mock_load_batches.call_args_list[0] == mock_load_batches.call_args_list[1]
@@ -173,21 +154,15 @@ def test_main_calls_load_batches_correctly(
         assert mock_load_batches.call_count == 1
 
 
-@pytest.mark.parametrize("additional_variables", [[], ["downward_shortwave"]])
 @pytest.mark.parametrize("derived_output_variables", [[], ["downwelling_shortwave"]])
 def test_main_dumps_correct_predictor(
     tmpdir,
     mock_load_batches: mock.MagicMock,
     mock_train_dense_model: mock.MagicMock,
-    additional_variables: Sequence[str],
     derived_output_variables: Sequence[str],
 ):
     artifacts = call_main(
-        tmpdir,
-        mock_load_batches,
-        additional_variables,
-        derived_output_variables,
-        use_validation_data=True,
+        tmpdir, mock_load_batches, derived_output_variables, use_validation_data=True,
     )
     mock_predictor = mock_train_dense_model.return_value
     if len(derived_output_variables) > 0:
@@ -198,21 +173,15 @@ def test_main_dumps_correct_predictor(
     assert artifacts.output_path in dump_predictor.dump.call_args[0]
 
 
-@pytest.mark.parametrize("additional_variables", [[], ["downward_shortwave"]])
 @pytest.mark.parametrize("derived_output_variables", [[], ["downwelling_shortwave"]])
 def test_main_uses_derived_model_only_if_needed(
     tmpdir,
     mock_load_batches: mock.MagicMock,
     mock_train_dense_model: mock.MagicMock,
-    additional_variables: Sequence[str],
     derived_output_variables: Sequence[str],
 ):
     artifacts = call_main(
-        tmpdir,
-        mock_load_batches,
-        additional_variables,
-        derived_output_variables,
-        use_validation_data=True,
+        tmpdir, mock_load_batches, derived_output_variables, use_validation_data=True,
     )
     if len(derived_output_variables) > 0:
         artifacts.MockDerivedModel.assert_called_once_with(
@@ -222,54 +191,60 @@ def test_main_uses_derived_model_only_if_needed(
         artifacts.MockDerivedModel.assert_not_called()
 
 
-@pytest.mark.parametrize("additional_variables", [[], ["downward_shortwave"]])
 @pytest.mark.parametrize("derived_output_variables", [[], ["downwelling_shortwave"]])
 @pytest.mark.parametrize("use_validation_data", [True, False])
 def test_main_calls_train_with_correct_arguments(
     tmpdir,
     mock_load_batches: mock.MagicMock,
     mock_train_dense_model: mock.MagicMock,
-    additional_variables: Sequence[str],
     derived_output_variables: Sequence[str],
     use_validation_data: bool,
 ):
     artifacts = call_main(
-        tmpdir,
-        mock_load_batches,
-        additional_variables,
-        derived_output_variables,
-        use_validation_data,
+        tmpdir, mock_load_batches, derived_output_variables, use_validation_data,
     )
     if use_validation_data:
         validation_batches = mock_load_batches.return_value
     else:
         validation_batches = []
     mock_train_dense_model.assert_called_once_with(
-        input_variables=artifacts.input_variables,
-        output_variables=artifacts.output_variables,
         hyperparameters=artifacts.hyperparameters,
         train_batches=mock_load_batches.return_value,
         validation_batches=validation_batches,
     )
 
 
+def get_hyperparameters(
+    model_type, hyperparameter_dict, input_variables, output_variables
+):
+    cls = get_hyperparameter_class(model_type)
+    try:
+        hyperparameters = cls(**hyperparameter_dict)
+    except TypeError:
+        hyperparameters = cls(
+            input_variables=input_variables,
+            output_variables=output_variables,
+            **hyperparameter_dict
+        )
+    return hyperparameters
+
+
 def get_config(
     tmpdir,
-    additional_variables,
     derived_output_variables,
     model_type,
-    hyperparameters,
+    hyperparameter_dict,
     use_validation_data: bool,
 ):
     base_dir = str(tmpdir)
     input_variables = ["air_temperature", "specific_humidity"]
     output_variables = ["dQ1", "dQ2"]
+    hyperparameters = get_hyperparameters(
+        model_type, hyperparameter_dict, input_variables, output_variables
+    )
     training_config = fv3fit.TrainingConfig(
         model_type=model_type,
-        input_variables=input_variables,
-        output_variables=output_variables,
         hyperparameters=hyperparameters,
-        additional_variables=additional_variables,
         derived_output_variables=derived_output_variables,
     )
     mock_dataset = get_mock_dataset(n_time=9)
@@ -323,7 +298,7 @@ def get_config(
         output_path=output_path,
     )
     return TestConfig(
-        args, input_variables, output_variables, output_path, mock_dataset
+        args, training_config.variables, hyperparameters, output_path, mock_dataset
     )
 
 
@@ -351,7 +326,7 @@ def cli_main(args: MainArgs):
 
 
 @pytest.mark.parametrize(
-    "model_type, hyperparameters",
+    "model_type, hyperparameter_dict",
     [
         pytest.param(
             "sklearn_random_forest",
@@ -389,19 +364,13 @@ def test_cli(
     use_local_download_path: bool,
     use_validation_data: bool,
     model_type: str,
-    hyperparameters,
+    hyperparameter_dict,
 ):
     """
     Test of fv3fit.train command-line interface.
     """
-    additional_variables = []
     config = get_config(
-        tmpdir,
-        additional_variables,
-        [],
-        model_type,
-        hyperparameters,
-        use_validation_data,
+        tmpdir, [], model_type, hyperparameter_dict, use_validation_data,
     )
     mock_load_batches.return_value = [config.mock_dataset for _ in range(6)]
     if use_local_download_path:

--- a/external/fv3fit/tests/training/test_train.py
+++ b/external/fv3fit/tests/training/test_train.py
@@ -1,5 +1,4 @@
 from typing import Callable, Optional, TextIO
-from fv3fit.typing import Dataclass
 import pytest
 import xarray as xr
 import numpy as np
@@ -23,17 +22,29 @@ def test_training_functions_exist():
     assert len(TRAINING_FUNCTIONS.keys()) > 0
 
 
-def train_identity_model(model_type, sample_func, hyperparameters):
+def get_default_hyperparameters(model_type, input_variables, output_variables):
+    cls = get_hyperparameter_class(model_type)
+    try:
+        hyperparameters = cls()
+    except TypeError:
+        hyperparameters = cls(
+            input_variables=input_variables, output_variables=output_variables
+        )
+    return hyperparameters
+
+
+def train_identity_model(model_type, sample_func):
     input_variables = ["var_in"]
     output_variables = ["var_out"]
+    hyperparameters = get_default_hyperparameters(
+        model_type, input_variables, output_variables
+    )
     data_array = sample_func()
     train_dataset = xr.Dataset(data_vars={"var_in": data_array, "var_out": data_array})
     train_batches = [train_dataset for _ in range(10)]
     val_batches = []
     train = fv3fit.get_training_function(model_type)
-    model = train(
-        input_variables, output_variables, hyperparameters, train_batches, val_batches,
-    )
+    model = train(hyperparameters, train_batches, val_batches,)
     data_array = sample_func()
     test_dataset = xr.Dataset(data_vars={"var_in": data_array, "var_out": data_array})
     return model, test_dataset
@@ -41,7 +52,6 @@ def train_identity_model(model_type, sample_func, hyperparameters):
 
 def assert_can_learn_identity(
     model_type,
-    hyperparameters: Dataclass,
     sample_func: Callable[[], xr.DataArray],
     max_rmse: float,
     regtest: Optional[TextIO] = None,
@@ -55,10 +65,7 @@ def assert_can_learn_identity(
         max_rmse: maximum permissible root mean squared error
         regtest: if given, write hash of output dataset to this file object
     """
-    hyperparameters = get_hyperparameter_class(model_type)()
-    model, test_dataset = train_identity_model(
-        model_type, sample_func=sample_func, hyperparameters=hyperparameters
-    )
+    model, test_dataset = train_identity_model(model_type, sample_func=sample_func)
     out_dataset = model.predict(test_dataset)
     rmse = np.mean((out_dataset["var_out"] - test_dataset["var_out"]) ** 2) ** 0.5
     assert rmse < max_rmse
@@ -80,32 +87,22 @@ def test_train_default_model_on_identity(model_type, regtest):
     fv3fit.set_random_seed(1)
     # don't set n_feature too high for this, because of curse of dimensionality
     n_sample, n_feature = int(5e3), 2
-    hyperparameters = get_hyperparameter_class(model_type)()
     sample_func = get_uniform_sample_func(size=(n_sample, n_feature))
 
     assert_can_learn_identity(
-        model_type,
-        hyperparameters=hyperparameters,
-        sample_func=sample_func,
-        max_rmse=0.05,
-        regtest=regtest,
+        model_type, sample_func=sample_func, max_rmse=0.05, regtest=regtest,
     )
 
 
 def test_train_with_same_seed_gives_same_result(model_type):
-    hyperparameters = get_hyperparameter_class(model_type)()
     n_sample, n_feature = 500, 2
     fv3fit.set_random_seed(0)
 
     sample_func = get_uniform_sample_func(size=(n_sample, n_feature))
-    first_model, test_dataset = train_identity_model(
-        model_type, sample_func, hyperparameters
-    )
+    first_model, test_dataset = train_identity_model(model_type, sample_func)
     fv3fit.set_random_seed(0)
     sample_func = get_uniform_sample_func(size=(n_sample, n_feature))
-    second_model, second_test_dataset = train_identity_model(
-        model_type, sample_func, hyperparameters
-    )
+    second_model, second_test_dataset = train_identity_model(model_type, sample_func)
     xr.testing.assert_equal(test_dataset, second_test_dataset)
     first_output = first_model.predict(test_dataset)
     second_output = second_model.predict(test_dataset)
@@ -115,10 +112,7 @@ def test_train_with_same_seed_gives_same_result(model_type):
 def test_predict_does_not_mutate_input(model_type):
     n_sample, n_feature = 100, 2
     sample_func = get_uniform_sample_func(size=(n_sample, n_feature))
-    hyperparameters = get_hyperparameter_class(model_type)()
-    model, test_dataset = train_identity_model(
-        model_type, sample_func=sample_func, hyperparameters=hyperparameters
-    )
+    model, test_dataset = train_identity_model(model_type, sample_func=sample_func)
     hash_before_predict = vcm.testing.checksum_dataarray_mapping(test_dataset)
     _ = model.predict(test_dataset)
     assert (
@@ -147,26 +141,19 @@ def test_train_default_model_on_nonstandard_identity(model_type):
     low, high = 100, 200
     # don't set n_feature too high for this, because of curse of dimensionality
     n_sample, n_feature = int(5e3), 2
-    hyperparameters = get_hyperparameter_class(model_type)()
     sample_func = get_uniform_sample_func(
         low=low, high=high, size=(n_sample, n_feature)
     )
 
     assert_can_learn_identity(
-        model_type,
-        hyperparameters=hyperparameters,
-        sample_func=sample_func,
-        max_rmse=0.05 * (high - low),
+        model_type, sample_func=sample_func, max_rmse=0.05 * (high - low),
     )
 
 
 def test_dump_and_load_default_maintains_prediction(model_type):
     n_sample, n_feature = 500, 2
     sample_func = get_uniform_sample_func(size=(n_sample, n_feature))
-    hyperparameters = get_hyperparameter_class(model_type)()
-    model, test_dataset = train_identity_model(
-        model_type, sample_func=sample_func, hyperparameters=hyperparameters
-    )
+    model, test_dataset = train_identity_model(model_type, sample_func=sample_func)
 
     original_result = model.predict(test_dataset)
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -177,7 +164,6 @@ def test_dump_and_load_default_maintains_prediction(model_type):
 
 
 def test_train_predict_multiple_stacked_dims(model_type):
-    hyperparameters = get_hyperparameter_class(model_type)()
     da = xr.DataArray(np.full(fill_value=1.0, shape=(5, 10, 15)), dims=["x", "y", "z"],)
     train_dataset = xr.Dataset(
         data_vars={"var_in_0": da, "var_in_1": da, "var_out_0": da, "var_out_1": da}
@@ -185,11 +171,10 @@ def test_train_predict_multiple_stacked_dims(model_type):
     train_batches = [train_dataset for _ in range(2)]
     val_batches = []
     train = fv3fit.get_training_function(model_type)
-    model = train(
-        ["var_in_0", "var_in_1"],
-        ["var_out_0", "var_out_1"],
-        hyperparameters,
-        train_batches,
-        val_batches,
+    input_variables = ["var_in_0", "var_in_1"]
+    output_variables = ["var_out_0", "var_out_1"]
+    hyperparameters = get_default_hyperparameters(
+        model_type, input_variables, output_variables
     )
+    model = train(hyperparameters, train_batches, val_batches,)
     model.predict(train_dataset)


### PR DESCRIPTION
Currently input/output variables is defined at the top level in TrainingConfig, and passed to training routines. This results in awkward assertion statements in some training routines that require certain inputs or outputs, or do not allow certain outputs. This PR modifies the handling of variables so that the hyperparameters class is responsible for telling the top level only the information it needs (what variables must be in the dataset for training), allowing each training routine to define how it determines inputs and outputs for its resulting Predictor.

Refactored public API:
- Hyperparameter classes now inherit from an ABC and must have a `variables` attribute or property method.
- input_variables and output_variables are moved from TrainingConfig onto RandomForestHyperparameters and DenseHyperparameters. When passed as top level properties in a configuration yaml, a deprecation warning will be emitted.
- `additional_variables` no longer needs to be specified when training random forests with mass scaling

(Delete this for the commit message)
You are encouraged to check the PR against the [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--A4lKrs~xg7w5Gsb39N6JLNQoAg-IlsYffZgTwyKEylty7NhY).
