### PR TITLE
fv3viz: cartopy coastline source

### DIFF
--- a/external/fv3viz/README.md
+++ b/external/fv3viz/README.md
@@ -3,3 +3,8 @@ functions: 1) those associated with plotting cubed-sphere tile data as maps usin
 histograms of set of timesteps useful for describing ML datasets.
 
 To get started, see example images and cubed-sphere plotting routines provided in the image gallery.
+
+Note: The default behavior of fv3viz is to redirect external downloads of shapefiles to an internally hosted repo which contains only the global-scale coastlines file. If other files are desired, please set the following environment variable prior to importing fv3viz to use cartopy's source:
+```
+export CARTOPY_EXTERNAL_DOWNLOADER="natural_earth"
+```

--- a/external/fv3viz/docs/conf.py
+++ b/external/fv3viz/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx_gallery.gen_gallery",
-    "recommonmark",
+    "m2r2",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -22,10 +22,17 @@ from functools import partial
 
 try:
     from cartopy import crs as ccrs
+    import cartopy
 except ImportError:
     pass
 
-# global
+# workaround to host our own global-scale coastline shapefile instead
+# of unreliable cartopy source
+cartopy.config["downloaders"][("shapefiles", "natural_earth")].url_template = (
+    "https://github.com/VulcanClimateModeling/vcm-ml-example-data/blob/"
+    "fv3viz-coastline-data/fv3net/fv3viz/coastline_shapefiles/"
+    "{resolution}_{category}/ne_{resolution}_{name}.zip"
+)
 
 _COORD_VARS = {
     VAR_LON_OUTER: [COORD_Y_OUTER, COORD_X_OUTER, "tile"],

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -29,7 +29,7 @@ except ImportError:
 # workaround to host our own global-scale coastline shapefile instead
 # of unreliable cartopy source
 cartopy.config["downloaders"][("shapefiles", "natural_earth")].url_template = (
-    "https://github.com/VulcanClimateModeling/vcm-ml-example-data/blob/"
+    "https://raw.githubusercontent.com/VulcanClimateModeling/vcm-ml-example-data/"
     "fv3viz-coastline-data/fv3net/fv3viz/coastline_shapefiles/"
     "{resolution}_{category}/ne_{resolution}_{name}.zip"
 )

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -19,6 +19,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 import warnings
 from functools import partial
+import os
 
 try:
     from cartopy import crs as ccrs
@@ -26,13 +27,14 @@ try:
 except ImportError:
     pass
 
-# workaround to host our own global-scale coastline shapefile instead
-# of unreliable cartopy source
-cartopy.config["downloaders"][("shapefiles", "natural_earth")].url_template = (
-    "https://raw.githubusercontent.com/VulcanClimateModeling/"
-    "vcm-ml-example-data/main/fv3net/fv3viz/coastline_shapefiles/"
-    "{resolution}_{category}/ne_{resolution}_{name}.zip"
-)
+if os.getenv("CARTOPY_EXTERNAL_DOWNLOADER") != "natural_earth":
+    # workaround to host our own global-scale coastline shapefile instead
+    # of unreliable cartopy source
+    cartopy.config["downloaders"][("shapefiles", "natural_earth")].url_template = (
+        "https://raw.githubusercontent.com/VulcanClimateModeling/"
+        "vcm-ml-example-data/main/fv3net/fv3viz/coastline_shapefiles/"
+        "{resolution}_{category}/ne_{resolution}_{name}.zip"
+    )
 
 _COORD_VARS = {
     VAR_LON_OUTER: [COORD_Y_OUTER, COORD_X_OUTER, "tile"],

--- a/external/fv3viz/fv3viz/_plot_cube.py
+++ b/external/fv3viz/fv3viz/_plot_cube.py
@@ -29,8 +29,8 @@ except ImportError:
 # workaround to host our own global-scale coastline shapefile instead
 # of unreliable cartopy source
 cartopy.config["downloaders"][("shapefiles", "natural_earth")].url_template = (
-    "https://raw.githubusercontent.com/VulcanClimateModeling/vcm-ml-example-data/"
-    "fv3viz-coastline-data/fv3net/fv3viz/coastline_shapefiles/"
+    "https://raw.githubusercontent.com/VulcanClimateModeling/"
+    "vcm-ml-example-data/main/fv3net/fv3viz/coastline_shapefiles/"
     "{resolution}_{category}/ne_{resolution}_{name}.zip"
 )
 

--- a/external/fv3viz/tests/test_visualize.py
+++ b/external/fv3viz/tests/test_visualize.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 from datetime import datetime
 import numpy as np
 import xarray as xr
@@ -21,6 +22,24 @@ from fv3viz._timestep_histograms import (
 
 def test_version():
     assert __version__ == "0.1.0"
+
+
+IMPORT_SCRIPT = """
+import fv3viz
+import cartopy
+print(cartopy.config["downloaders"][("shapefiles", "natural_earth")].url_template)
+"""
+
+
+@pytest.mark.parametrize(
+    ["env_var", "vcm_in_url"], [("natural_earth", False), ("", True)]
+)
+def test_cartopy_downloader(monkeypatch, env_var, vcm_in_url):
+    monkeypatch.setenv("CARTOPY_EXTERNAL_DOWNLOADER", env_var)
+    downloader = subprocess.run(
+        ["python", "-c", IMPORT_SCRIPT], capture_output=True, encoding="utf8"
+    ).stdout
+    assert ("vcm-ml-example-data" in downloader) == vcm_in_url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fv3net's fv3viz uses cartopy's coastlines feature, which relies on external data that is intermittently unavailable, causing the fv3net image and the integration tests to fail. This PR redirects fv3viz's cartopy downloads to our vcm-ml-example-data repo so that there is no dependence on outside data hosting. 

Significant internal changes:
- modifies the cartopy config when fv3viz is imported to point its downloaders to vcm-ml-example-data coastline shapefile (other external cartopy features will fail now but none are used by fv3viz, and they could be added if really needed)


