### PR TITLE
Revert prog run logging config change

### DIFF
--- a/workflows/prognostic_c48_run/runtime/main.py
+++ b/workflows/prognostic_c48_run/runtime/main.py
@@ -15,7 +15,8 @@ import runtime
 STATISTICS_LOG_NAME = "statistics"
 PROFILES_LOG_NAME = "profiles"
 
-logging.getLogger("runtime").setLevel(logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
+
 logging.getLogger("fv3gfs.util").setLevel(logging.WARN)
 logging.getLogger("fsspec").setLevel(logging.WARN)
 logging.getLogger("urllib3").setLevel(logging.WARN)


### PR DESCRIPTION
#1345 (specifically https://github.com/VulcanClimateModeling/fv3net/pull/1345/commits/652d97818677c3fb628535353a87d784bf6e9cc8) introduced a change to the prognostic run logging configuration which resulted in #1350. This PR reverts that change and resolves #1350.

Since the loggers in the prog run use the convention of being named `__name__`, setting `logging.getLogger("runtime").setLevel(logging.DEBUG)` does not work as intended (would need to set level for `runtime.loop` etc). Using basicConfig worked well, so going back to that.