### PR TITLE
Add prepare config python apis

### DIFF
--- a/workflows/prognostic_c48_run/docs/config-usage.rst
+++ b/workflows/prognostic_c48_run/docs/config-usage.rst
@@ -1,7 +1,7 @@
 .. _config usage:
 
-Configuration Usage
--------------------
+CLI Configuration Preparation
+-----------------------------
 
 The prognostic run can can be configured to run with the following
 
@@ -13,6 +13,7 @@ The prognostic run can can be configured to run with the following
 The prognostic run provides a command line script ```prepare-config``  to
 minimize the boilerplate required to configure a run. This script allows
 specifying changes over the "default" configurations stored `here <https://github.com/VulcanClimateModeling/fv3net/tree/master/external/fv3kube/fv3kube/base_yamls>`_.
+
 
 .. _baseline:
 
@@ -166,3 +167,12 @@ The desired chunking can be specified for each diagnostic file to be output.
 
 .. _fv3config: https://fv3config.readthedocs.io/en/latest/
 .. _fv3fit: https://vulcanclimatemodeling.com/docs/fv3fit/
+
+
+Python Configuration Preparation
+--------------------------------
+
+A python API analog to ``prepare-config`` can also be used for configuring runs
+
+.. automodule:: runtime.segmented_run.prepare_config
+    :members:

--- a/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
@@ -17,6 +17,9 @@ from runtime.config import UserConfig
 from runtime.steppers.machine_learning import MachineLearningConfig
 
 
+__all__ = ["to_fv3config", "InitialCondition"]
+
+
 logger = logging.getLogger(__name__)
 
 PROGNOSTIC_DIAG_TABLE = "/fv3net/workflows/prognostic_c48_run/diag_table_prognostic"
@@ -167,9 +170,15 @@ def to_fv3config(
     configurations
 
     Args:
-        dict_:  a dictionary containing prognostic run configurations.  This
-            dictionary combines fv3config-related keys with :py:class:`UserConfig`
-            settings.
+        ``dict_``:  a dictionary containing prognostic run configurations.  This
+            dictionary combines fv3config-related keys with
+            :py:class:`runtime.config.UserConfig` settings.
+        initial_condition: modify the initial_conditions if provided, otherwise
+            leaves ``dict_`` unchanged.
+
+    Returns:
+        an fv3config configuration dictionary that can be operated on with
+        fv3config APIs.
     """
     user_config = user_config_from_dict_and_args(
         dict_,

--- a/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
+++ b/workflows/prognostic_c48_run/runtime/segmented_run/prepare_config.py
@@ -77,28 +77,30 @@ def _create_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def user_config_from_dict_and_args(config_dict: dict, args) -> UserConfig:
+def user_config_from_dict_and_args(
+    config_dict: dict, nudging_url, model_url, diagnostic_ml
+) -> UserConfig:
     """Ideally this function could be replaced by dacite.from_dict
     without needing any information from args.
     """
     if "nudging" in config_dict:
         config_dict["nudging"]["restarts_path"] = config_dict["nudging"].get(
-            "restarts_path", args.initial_condition_url
+            "restarts_path", nudging_url
         )
 
     user_config = dacite.from_dict(UserConfig, config_dict)
 
     # insert command line option overrides
     if user_config.scikit_learn is None:
-        if args.model_url:
+        if model_url:
             user_config.scikit_learn = MachineLearningConfig(
-                model=list(args.model_url), diagnostic_ml=args.diagnostic_ml
+                model=list(model_url), diagnostic_ml=diagnostic_ml
             )
     else:
-        if args.model_url:
-            user_config.scikit_learn.model = list(args.model_url)
-        if args.diagnostic_ml:
-            user_config.scikit_learn.diagnostic_ml = args.diagnostic_ml
+        if model_url:
+            user_config.scikit_learn.model = list(model_url)
+        if diagnostic_ml:
+            user_config.scikit_learn.diagnostic_ml = diagnostic_ml
 
     if user_config.nudging and user_config.scikit_learn:
         raise NotImplementedError(
@@ -121,55 +123,90 @@ def _diag_table_overlay(
     return {"diag_table": diag_table}
 
 
-def prepare_config(args):
-    # Get model config with prognostic run updates
-    with open(args.user_config, "r") as f:
-        dict_ = yaml.safe_load(f)
-
-    user_config = user_config_from_dict_and_args(dict_, args)
-
-    fv3config_config = {key: dict_[key] for key in FV3CONFIG_KEYS if key in dict_}
-    final = _prepare_config_from_parsed_config(
-        user_config, fv3config_config, dict_["base_version"], args
-    )
-    fv3config.dump(final, sys.stdout)
+FV3Config = dict
 
 
-def _prepare_config_from_parsed_config(
-    user_config: UserConfig, fv3_config: dict, base_version: str, args
-):
-    if not set(fv3_config) <= FV3CONFIG_KEYS:
-        raise ValueError(
-            f"{fv3_config.keys()} contains a key that fv3config does not handle. "
-            "Python runtime configurations should be specified in the user_config "
-            "argument."
-        )
+@dataclasses.dataclass
+class InitialCondition:
+    """An initial condition with the format ``{base_url}/{timestep}``
 
-    physics_timestep = timedelta(
+    Attributes:
+        base_url: a location in GCS or local
+        timestep: a YYYYMMDD.HHMMSS timestamp
+    """
+
+    base_url: str
+    timestep: str
+
+    @property
+    def overlay(self):
+        return fv3kube.c48_initial_conditions_overlay(self.base_url, self.timestep)
+
+
+def get_physics_timestep(dict_):
+    base_version = dict_["base_version"]
+    fv3_config = {key: dict_[key] for key in FV3CONFIG_KEYS if key in dict_}
+    return timedelta(
         seconds=fv3kube.merge_fv3config_overlays(
             fv3kube.get_base_fv3config(base_version), fv3_config
         )["namelist"]["coupler_nml"]["dt_atmos"]
     )
 
-    # To simplify the configuration flow, updates should be implemented as
+
+def to_fv3config(
+    dict_: dict,
+    initial_condition: InitialCondition,
+    nudging_url: str,
+    model_url: Sequence[str] = (),
+    diagnostic_ml: bool = False,
+) -> FV3Config:
+    """Convert a loaded prognostic run yaml ``dict_`` into an fv3config
+    dictionary depending on some options
+
+    See the arguments for setting initial conditions and other runtime model
+    configurations
+
+    Args:
+        dict_:  a dictionary containing prognostic run configurations.  This
+            dictionary combines fv3config-related keys with :py:class:`UserConfig`
+            settings.
+    """
+    user_config = user_config_from_dict_and_args(
+        dict_,
+        nudging_url=nudging_url,
+        model_url=model_url,
+        diagnostic_ml=diagnostic_ml,
+    )
+
     # overlays (i.e. diffs) requiring only a small number of inputs. In
     # particular, overlays should not require access to the full configuration
     # dictionary.
-    overlays = [
-        fv3kube.get_base_fv3config(base_version),
-        fv3kube.c48_initial_conditions_overlay(
-            args.initial_condition_url, args.ic_timestep
-        ),
+    return fv3kube.merge_fv3config_overlays(
+        fv3kube.get_base_fv3config(dict_["base_version"]),
+        initial_condition.overlay,
         SUPPRESS_RANGE_WARNINGS,
         dataclasses.asdict(user_config),
-        fv3_config,
+        {key: dict_[key] for key in FV3CONFIG_KEYS if key in dict_},
         _diag_table_overlay(user_config.fortran_diagnostics),
         file_configs_to_namelist_settings(
-            user_config.fortran_diagnostics, physics_timestep
+            user_config.fortran_diagnostics, get_physics_timestep(dict_)
         ),
-    ]
+    )
 
-    return fv3kube.merge_fv3config_overlays(*overlays)
+
+def prepare_config(args):
+    # Get model config with prognostic run updates
+    with open(args.user_config, "r") as f:
+        dict_ = yaml.safe_load(f)
+
+    final = to_fv3config(
+        dict_,
+        InitialCondition(args.initial_condition_url, args.ic_timestep),
+        nudging_url=args.initial_condition_url,
+        model_url=args.model_url,
+        diagnostic_ml=args.diagnostic_ml,
+    )
+    fv3config.dump(final, sys.stdout)
 
 
 def main():

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -27,12 +27,6 @@ def test_prepare_ml_config_regression(regtest, argv):
 
 
 def test_get_user_config_is_valid():
-    class Args:
-        model_url = []
-        diagnostic_ml = True
-        initial_condition_url = "gs://some-url"
-        ic_timestep = "20160801.000000"
-        nudge_to_observations = False
 
     dict_ = {
         "base_version": "v0.5",
@@ -45,6 +39,8 @@ def test_get_user_config_is_valid():
         ],
     }
 
-    config = prepare_config.user_config_from_dict_and_args(dict_, Args)
+    config = prepare_config.user_config_from_dict_and_args(
+        dict_, model_url=[], diagnostic_ml=True, nudging_url="gs://some-url",
+    )
     # validate using dacite.from_dict
     dacite.from_dict(UserConfig, dataclasses.asdict(config))

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -1,3 +1,6 @@
+from workflows.prognostic_c48_run.runtime.segmented_run.prepare_config import (
+    to_fv3config,
+)
 from runtime.segmented_run import prepare_config
 import dacite
 import dataclasses
@@ -44,3 +47,16 @@ def test_get_user_config_is_valid():
     )
     # validate using dacite.from_dict
     dacite.from_dict(UserConfig, dataclasses.asdict(config))
+
+
+def test_to_fv3config_initial_conditions():
+    my_ic = "my_ic"
+    final = to_fv3config(
+        {"initial_conditions": my_ic, "base_version": "v0.5"},
+        initial_condition=None,
+        model_url=[],
+        diagnostic_ml=True,
+        nudging_url="gs://some-url",
+    )
+
+    final["initial_conditions"] = my_ic

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -1,6 +1,4 @@
-from workflows.prognostic_c48_run.runtime.segmented_run.prepare_config import (
-    to_fv3config,
-)
+from runtime.segmented_run.prepare_config import to_fv3config
 from runtime.segmented_run import prepare_config
 import dacite
 import dataclasses

--- a/workflows/prognostic_c48_run/tests/test_prepare_config.py
+++ b/workflows/prognostic_c48_run/tests/test_prepare_config.py
@@ -59,4 +59,4 @@ def test_to_fv3config_initial_conditions():
         nudging_url="gs://some-url",
     )
 
-    final["initial_conditions"] = my_ic
+    assert final["initial_conditions"] == my_ic


### PR DESCRIPTION
Add a python API for preparing configs with simple initial conditions. I didn't modify the CLI, since I am using python APIs to build configs for my emulations runs anyway.

I suggest reviewing one commit at a time to separate refactors from the new feature.