### PR TITLE
Prognostic run: fix missing nudging tendency names

### DIFF
--- a/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
+++ b/workflows/prognostic_c48_run/runtime/diagnostics/compute.py
@@ -9,6 +9,7 @@ from runtime.names import (
     DELP,
     PHYSICS_PRECIP_RATE,
     TENDENCY_TO_STATE_NAME,
+    STATE_NAME_TO_TENDENCY,
 )
 
 logger = logging.getLogger(__name__)
@@ -103,9 +104,10 @@ def compute_diagnostics(
             units="W/m^2"
         ).assign_attrs(description=f"column integrated heating due to {label}"),
     }
-    if DELP in tendency:
+    delp_tendency = STATE_NAME_TO_TENDENCY[DELP]
+    if delp_tendency in tendency:
         net_mass_tendency = vcm.mass_integrate(
-            xr.ones_like(tendency[DELP]), tendency[DELP], dim="z"
+            xr.ones_like(tendency[delp_tendency]), tendency[delp_tendency], dim="z"
         ).assign_attrs(
             units="kg/m^2/s",
             description=f"column-integrated mass tendency due to {label}",

--- a/workflows/prognostic_c48_run/runtime/names.py
+++ b/workflows/prognostic_c48_run/runtime/names.py
@@ -24,6 +24,9 @@ TENDENCY_TO_STATE_NAME: Mapping[Hashable, Hashable] = {
     "dQ2": SPHUM,
     "dQu": EAST_WIND,
     "dQv": NORTH_WIND,
+    "dQx_wind": "x_wind",
+    "dQy_wind": "y_wind",
+    "dQp": DELP,
 }
 STATE_NAME_TO_TENDENCY = {value: key for key, value in TENDENCY_TO_STATE_NAME.items()}
 

--- a/workflows/prognostic_c48_run/tests/test_nudging.py
+++ b/workflows/prognostic_c48_run/tests/test_nudging.py
@@ -84,7 +84,7 @@ def test__label_to_time():
 # tests of nudging tendency below adapted from fv3gfs.util versions
 
 
-@pytest.fixture(params=["empty", "one_var", "two_vars"])
+@pytest.fixture(params=["empty", "one_var", "multiple_vars"])
 def state(request):
     if request.param == "empty":
         return {}
@@ -94,13 +94,22 @@ def state(request):
                 np.ones([5]), dims=["dim1"], attrs={"units": "K"}
             )
         }
-    elif request.param == "two_vars":
+    elif request.param == "multiple_vars":
         return {
             "air_temperature": xr.DataArray(
                 np.ones([5]), dims=["dim1"], attrs={"units": "K"}
             ),
             "specific_humidity": xr.DataArray(
                 np.ones([5]), dims=["dim_2"], attrs={"units": "kg/kg"}
+            ),
+            "pressure_thickness_of_atmospheric_layer": xr.DataArray(
+                np.ones([5]), dims=["dim_2"], attrs={"units": "Pa"}
+            ),
+            "x_wind": xr.DataArray(
+                np.ones([5]), dims=["dim_2"], attrs={"units": "m/s"}
+            ),
+            "y_wind": xr.DataArray(
+                np.ones([5]), dims=["dim_2"], attrs={"units": "m/s"}
             ),
         }
     else:


### PR DESCRIPTION
PR https://github.com/VulcanClimateModeling/fv3net/commit/06934dc6494cd282cb404b3624c084292a1329f4 broke the nudging runs because I changed the nudging to use the same tendency to state name dict as the ML stepper, but forgot to add names for nudging tendencies that aren't predicted by the ML (pressure, D grid winds). This adds those to `names.TENDENCY_TO_STATE_NAME` to avoid key errors.
