### PR TITLE
Online emulator master fixes

### DIFF
--- a/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
+++ b/external/fv3fit/fv3fit/emulation/data/dict_dataset.py
@@ -19,7 +19,7 @@ def read_variables_as_dict(fs, url, variables):
 def read_variables_greedily_as_tuple(fs, url, variables):
     url = url.numpy().decode()
     print(f"opening {url}")
-    ds = vcm.open_remote_nc(fs, url)
+    ds = vcm.DerivedMapping(vcm.open_remote_nc(fs, url))
     return tuple([tf.convert_to_tensor(ds[v], dtype=tf.float32) for v in variables])
 
 

--- a/external/fv3fit/fv3fit/train_emulator.py
+++ b/external/fv3fit/fv3fit/train_emulator.py
@@ -66,7 +66,7 @@ def main(config: Config):
 
     id_ = pathlib.Path(os.getcwd()).name
 
-    with tf.summary.create_file_writer(f"/data/emulator/{id_}").as_default():
+    with tf.summary.create_file_writer(f"data/emulator/{id_}").as_default():
         emulator.batch_fit(train_dataset.shuffle(100_000), validation_data=test_dataset)
 
     train_scores = emulator.score(train_dataset)


### PR DESCRIPTION
Fix a bug requiring the `fv3fit.train_emulator` to be run with root access and allow training with any derived variable.